### PR TITLE
Multiple games tests

### DIFF
--- a/.idea/retrosheet-rs.iml
+++ b/.idea/retrosheet-rs.iml
@@ -5,6 +5,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test_resources" type="java-test-resource" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/src/event.rs
+++ b/src/event.rs
@@ -339,6 +339,8 @@ pub enum PlayDescription {
     /// throws that resulted in the out. Note that there wouldn't be errors here since the
     /// implication is that they were caught.
     PickOffCaughtStealing(Base, Vec<Fielder>),
+    /// A normal caught stealing event.
+    CaughtStealing(Base, Vec<Fielder>),
     /// A batter lining into a double play. Should be followed with an `LDP` modifier, but we don't
     /// verify this.
     LinedIntoDoublePlay {

--- a/src/event.rs
+++ b/src/event.rs
@@ -608,7 +608,7 @@ impl<'a> From<&'a [u8]> for HitLocation {
 pub enum PlayModifier {
     /// A hit of some kind, possibly with a specific location.
     HitWithLocation(HitType, Option<HitLocation>),
-    /// Just a hit location (used wit home runs).
+    /// Just a hit location (used with home runs).
     HitLocation(HitLocation),
     /// appeal play
     AppealPlay,

--- a/src/event.rs
+++ b/src/event.rs
@@ -314,8 +314,8 @@ pub enum PlayDescription {
     InsideTheParkHomeRun(Vec<Fielder>),
     /// No play was made. Used when a substitution immediately follows.
     NoPlay,
-    /// A stolen base, with the base information.
-    StolenBase(Base),
+    /// Stolen base(s), with the base information.
+    StolenBase(Vec<Base>),
     /// The player was hit by a pitch.
     HitByPitch,
     /// Catcher interference. Technically, this also covers interference by the pitcher or first

--- a/src/event.rs
+++ b/src/event.rs
@@ -612,6 +612,8 @@ pub enum PlayModifier {
     HitLocation(HitLocation),
     /// appeal play
     AppealPlay,
+    /// bunt hit foul (usually with two strikes)
+    BuntFoul,
     /// bunt grounded into double play
     BuntGroundedIntoDoublePlay,
     /// batter interference

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -108,6 +108,15 @@ named!(play_desc_pickoff_cs (&[u8]) -> PlayDescription, do_parse!(
     (PlayDescription::PickOffCaughtStealing(base, throws))
 ));
 
+named!(play_desc_cs (&[u8]) -> PlayDescription, do_parse!(
+    tag!("CS") >>
+    base: base >>
+    tag!("(") >>
+    throws: many1!(complete!(fielder)) >>
+    tag!(")") >>
+    (PlayDescription::CaughtStealing(base, throws))
+));
+
 named!(play_desc_pickoff (&[u8]) -> PlayDescription, do_parse!(
     tag!("PO") >>
     base: base >>
@@ -170,6 +179,7 @@ named!(play_description (&[u8]) -> PlayDescription, alt_complete!(
     map!(preceded!(tag!("S"), many0!(fielder)), PlayDescription::Single) |
     map!(preceded!(tag!("D"), many0!(fielder)), PlayDescription::Double) |
     map!(preceded!(tag!("T"), many0!(fielder)), PlayDescription::Triple) |
+    play_desc_cs |
     complete!(play_desc_ltp) |
     complete!(play_desc_ldp) |
     complete!(play_desc_pickoff_cs) |
@@ -828,6 +838,8 @@ mod tests {
         ]), play_description(b"PO1(E3)"));
         assert_parsed!(PlayDescription::PickOffCaughtStealing(Base::Second, vec![1, 3, 6, 1]),
             play_description(b"POCS2(1361)"));
+        assert_parsed!(PlayDescription::CaughtStealing(Base::Second, vec![1, 3, 6, 1]),
+            play_description(b"CS2(1361)"));
         assert_parsed!(desc6, play_description(b"8(B)84(2)"));
         assert_parsed!(desc7, play_description(b"3(B)3(1)"));
         assert_parsed!(desc8, play_description(b"1(B)16(2)63(1)"));

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -304,10 +304,12 @@ named!(advance (&[u8]) -> Advance, do_parse!(
 
 named!(play_event (&[u8]) -> PlayEvent, do_parse!(
     play_desc: complete!(play_description) >>
+    opt!(complete!(alt!(tag!("!") | tag!("?")))) >>
     modifiers: many0!(preceded!(tag!("/"), complete!(modifier))) >>
     advances: opt!(complete!(preceded!(tag!("."),
                              separated_list!(tag!(";"),
                                              advance)))) >>
+    opt!(complete!(tag!("#"))) >>
     (PlayEvent {
         description: play_desc,
         modifiers: modifiers,

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -205,6 +205,7 @@ named!(hit_with_location (&[u8]) -> PlayModifier, do_parse!(
 named!(modifier (&[u8]) -> PlayModifier, do_parse!(
     m: alt_complete!(
         value!(PlayModifier::AppealPlay, tag!("AP")) |
+        value!(PlayModifier::BuntFoul, tag!("BF")) |
         value!(PlayModifier::BuntGroundedIntoDoublePlay, tag!("BGDP")) |
         value!(PlayModifier::BatterInterference, tag!("BINT")) |
         value!(PlayModifier::LineDriveBunt, tag!("BL")) |
@@ -597,6 +598,7 @@ mod tests {
         assert_parsed!(PlayModifier::HitWithLocation(HitType::PopFly, Some(HitLocation::_4MS)), modifier(b"P4MS"));
 
         assert_parsed!(PlayModifier::AppealPlay, modifier(b"AP"));
+        assert_parsed!(PlayModifier::BuntFoul, modifier(b"BF"));
         assert_parsed!(PlayModifier::BuntGroundedIntoDoublePlay, modifier(b"BGDP"));
         assert_parsed!(PlayModifier::BatterInterference, modifier(b"BINT"));
         assert_parsed!(PlayModifier::LineDriveBunt, modifier(b"BL"));

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -152,7 +152,7 @@ named!(play_desc_ltp (&[u8]) -> PlayDescription, do_parse!(
 ));
 
 named!(play_description (&[u8]) -> PlayDescription, alt_complete!(
-    map!(preceded!(tag!("SB"), base), PlayDescription::StolenBase) |
+    map!(separated_nonempty_list!(tag!(";"), preceded!(tag!("SB"), base)), PlayDescription::StolenBase) |
     value!(PlayDescription::OtherAdvance, tag!("OA")) |
     value!(PlayDescription::IntentionalWalk, tag!("IW")) |
     value!(PlayDescription::IntentionalWalk, tag!("I")) |
@@ -812,7 +812,8 @@ mod tests {
         assert_parsed!(desc5, play_description(b"W+WP"));
         assert_parsed!(PlayDescription::HitByPitch, play_description(b"HP"));
         assert_parsed!(PlayDescription::NoPlay, play_description(b"NP"));
-        assert_parsed!(PlayDescription::StolenBase(Base::Third), play_description(b"SB3"));
+        assert_parsed!(PlayDescription::StolenBase(vec![Base::Third]), play_description(b"SB3"));
+        assert_parsed!(PlayDescription::StolenBase(vec![Base::Third, Base::Second]), play_description(b"SB3;SB2"));
         assert_parsed!(PlayDescription::CatcherInterference(1), play_description(b"C/E1"));
         assert_parsed!(PlayDescription::CatcherInterference(2), play_description(b"C/E2"));
         assert_parsed!(PlayDescription::CatcherInterference(3), play_description(b"C/E3"));

--- a/test_resources/2016CHN.EVN
+++ b/test_resources/2016CHN.EVN
@@ -1,0 +1,13130 @@
+id,CHN201604110
+version,2
+info,visteam,CIN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/04/11
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,tumpj901
+info,ump1b,kellj901
+info,ump2b,onorb901
+info,ump3b,porta901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,48
+info,winddir,ltor
+info,windspeed,12
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,183
+info,attendance,40882
+info,wp,warra001
+info,lp,cingt001
+info,save,rondh001
+start,cozaz001,"Zack Cozart",0,1,6
+start,suare001,"Eugenio Suarez",0,2,5
+start,vottj001,"Joey Votto",0,3,3
+start,philb001,"Brandon Phillips",0,4,4
+start,mesod001,"Devin Mesoraco",0,5,2
+start,brucj001,"Jay Bruce",0,6,9
+start,duvaa001,"Adam Duvall",0,7,7
+start,finnb001,"Brandon Finnegan",0,8,1
+start,hamib001,"Billy Hamilton",0,9,8
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,solej001,"Jorge Soler",1,6,7
+start,russa002,"Addison Russell",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,cozaz001,21,BBFX,S49/L-
+play,1,0,suare001,32,BBBCFFX,5/L
+play,1,0,vottj001,11,FBX,S7/L.1-3;B-2(TH)
+play,1,0,philb001,31,BBF*BX,63/G.3-H
+play,1,0,mesod001,32,BBCCF*BC,K
+play,1,1,fowld001,00,X,9/L
+play,1,1,heywj001,10,BX,7/L
+play,1,1,bryak001,00,X,8/F
+play,2,0,brucj001,00,X,13/G
+play,2,0,duvaa001,02,CFX,53/G
+play,2,0,finnb001,02,CSC,K
+play,2,1,rizza001,02,CFFX,8/F-
+play,2,1,zobrb001,11,BCX,63/G
+play,2,1,solej001,32,BSFBBFX,53/G
+play,3,0,hamib001,12,FCBX,HR/7/F
+play,3,0,cozaz001,00,X,13/G
+play,3,0,suare001,02,CCX,7/F
+play,3,0,vottj001,32,CBBFBX,63/G
+play,3,1,russa002,00,X,7/L
+play,3,1,rossd001,31,FBBBB,W
+play,3,1,lestj001,12,FCBB,WP.1-2
+play,3,1,lestj001,32,FCBB.BB,W
+play,3,1,fowld001,32,BC*BS*BS,K
+play,3,1,heywj001,12,CCBFB,PB.2-3;1-2
+play,3,1,heywj001,32,CCBFB.FBFX,63/G
+play,4,0,philb001,22,SBSBFFFX,S8/L
+play,4,0,mesod001,22,BFFFBX,163/G.1-2
+play,4,0,brucj001,11,CB>S,SB3
+play,4,0,brucj001,32,CB>S.BBS,K
+play,4,0,duvaa001,30,BBBB,W
+play,4,0,finnb001,02,CFX,S8/L.3-H;1-3
+play,4,0,hamib001,11,CBX,7/L
+play,4,1,bryak001,00,,NP
+sub,dejei002,"Ivan De Jesus",0,1,6
+play,4,1,bryak001,02,.CFC,K
+play,4,1,rizza001,31,BCBBB,W
+play,4,1,zobrb001,00,X,6/L
+play,4,1,solej001,32,SBS*BF*B>X,8/F
+play,5,0,dejei002,02,CFFFX,9/F
+play,5,0,suare001,12,CFBS,K
+play,5,0,vottj001,22,CBBFC,K
+play,5,1,russa002,32,CBFBBB,W
+play,5,1,rossd001,12,BSSS,K
+play,5,1,lestj001,00,X,14/BG/SH.1-2
+play,5,1,fowld001,21,SB*BX,53/G
+play,6,0,philb001,00,X,7/F
+play,6,0,mesod001,32,CFBBB*B,W
+play,6,0,brucj001,12,FBFX,46(1)3/GDP
+play,6,1,heywj001,32,CBFBBS,K
+play,6,1,bryak001,11,BSX,E5/G.B-2
+play,6,1,rizza001,12,CFFBX,7/F-
+play,6,1,zobrb001,01,CX,53/G
+play,7,0,duvaa001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,7,0,duvaa001,10,.BX,D7/L
+play,7,0,finnb001,01,LX,FC2/G.2X3(265);B-2(TH)
+play,7,0,hamib001,32,LCBBFBS,K
+play,7,0,dejei002,32,BBCBFX,3/P
+play,7,1,solej001,01,FX,53/G
+play,7,1,russa002,32,CBFBBFC,K
+play,7,1,rossd001,12,SBFFFX,S8/L
+play,7,1,cahit001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,7,1,szczm001,30,.*B*BBB,W.1-2
+play,7,1,fowld001,00,,NP
+sub,cothc001,"Caleb Cotham",0,8,1
+play,7,1,fowld001,31,.BBFBB,W.2-3;1-2
+play,7,1,heywj001,00,,NP
+sub,cingt001,"Tony Cingrani",0,8,1
+play,7,1,heywj001,02,.CFX,S9/L.3-H;2-H;1-3
+play,7,1,bryak001,21,1FBBX,63/G
+play,8,0,suare001,00,,NP
+sub,warra001,"Adam Warren",1,9,1
+play,8,0,suare001,00,.X,63/G
+play,8,0,vottj001,21,BBFX,S9/L
+play,8,0,philb001,12,FBS1FX,23/G-.1-2
+play,8,0,mesod001,11,BCX,53/G
+play,8,1,rizza001,22,CFBBX,43/G
+play,8,1,zobrb001,31,BBFBB,W
+play,8,1,solej001,12,C11BSFB,WP.1-2
+play,8,1,solej001,32,C11BSFB.*BH,HP
+play,8,1,russa002,00,,NP
+sub,diazj005,"Jumbo Diaz",0,8,1
+play,8,1,russa002,00,.X,HR/78/F.2-H;1-H
+play,8,1,rossd001,11,BCX,53/G
+play,8,1,warra001,00,,NP
+sub,kawam001,"Munenori Kawasaki",1,9,11
+play,8,1,kawam001,22,.CSBBX,9/L
+play,9,0,brucj001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,9,0,brucj001,00,,NP
+sub,rondh001,"Hector Rondon",1,6,1
+play,9,0,brucj001,00,,NP
+sub,kawam001,"Munenori Kawasaki",1,9,5
+play,9,0,brucj001,02,...CFC,K
+play,9,0,duvaa001,12,CSBC,K
+play,9,0,diazj005,00,,NP
+sub,sches001,"Scott Schebler",0,8,11
+play,9,0,sches001,12,.CFFBC,K
+data,er,finnb001,2
+data,er,cothc001,0
+data,er,cingt001,2
+data,er,diazj005,1
+data,er,lestj001,3
+data,er,cahit001,0
+data,er,warra001,0
+data,er,rondh001,0
+id,CHN201604130
+version,2
+info,visteam,CIN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/04/13
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,kellj901
+info,ump1b,onorb901
+info,ump2b,porta901
+info,ump3b,tumpj901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,seipb701
+info,temp,43
+info,winddir,fromrf
+info,windspeed,8
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,183
+info,attendance,36496
+info,wp,lackj001
+info,lp,simoa001
+info,save,
+start,hamib001,"Billy Hamilton",0,1,8
+start,suare001,"Eugenio Suarez",0,2,5
+start,vottj001,"Joey Votto",0,3,3
+start,philb001,"Brandon Phillips",0,4,4
+start,brucj001,"Jay Bruce",0,5,9
+start,sches001,"Scott Schebler",0,6,7
+start,dejei002,"Ivan De Jesus",0,7,6
+start,barnt001,"Tucker Barnhart",0,8,2
+start,simoa001,"Alfredo Simon",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,zobrb001,"Ben Zobrist",1,3,4
+start,rizza001,"Anthony Rizzo",1,4,3
+start,bryak001,"Kris Bryant",1,5,5
+start,montm001,"Miguel Montero",1,6,2
+start,solej001,"Jorge Soler",1,7,7
+start,russa002,"Addison Russell",1,8,6
+start,lackj001,"John Lackey",1,9,1
+play,1,0,hamib001,00,X,D9/G
+play,1,0,suare001,11,BSX,S9/L.2-3
+play,1,0,vottj001,12,FFB>B,SB2
+play,1,0,vottj001,32,FFB>B.*BB,W
+play,1,0,philb001,12,BFFFS,K
+play,1,0,brucj001,10,BX,8/F/SF.3-H;2-3
+play,1,0,sches001,02,FSX,43/G
+play,1,1,fowld001,31,CBBBX,D9/L+
+play,1,1,heywj001,02,CFFFFS,K
+play,1,1,zobrb001,32,CBSBBB,W
+play,1,1,rizza001,22,CBBSFFF>B,SB3;SB2
+play,1,1,rizza001,32,CBBSFFF>B.F*B,W
+play,1,1,bryak001,32,BBBCFB,W.3-H;2-3;1-2
+play,1,1,montm001,12,CFBFX,S7/L.3-H;2-3;1-2
+play,1,1,solej001,20,BBX,7/F/SF.3-H
+play,1,1,russa002,20,BBX,S9/L.2-H;1-2
+play,1,1,lackj001,22,BSCBX,S9/G.2-H;1-2
+play,1,1,fowld001,00,,NP
+sub,strad003,"Dan Straily",0,9,1
+play,1,1,fowld001,11,.BCH,HP.2-3;1-2
+play,1,1,heywj001,12,BCSFS,K
+play,2,0,dejei002,10,BX,8/F
+play,2,0,barnt001,31,BCBBB,W
+play,2,0,strad003,12,LBMX,36(1)/FO/BG
+play,2,0,hamib001,22,BCCBC,K
+play,2,1,zobrb001,22,FFBBX,8/F
+play,2,1,rizza001,01,CX,8/F
+play,2,1,bryak001,00,X,9/L
+play,3,0,suare001,30,BBBB,W
+play,3,0,vottj001,00,X,S9/L.1-2
+play,3,0,philb001,00,X,4(1)3/GDP.2-3
+play,3,0,brucj001,10,BX,9/F
+play,3,1,montm001,30,BBBB,W
+play,3,1,solej001,22,BCSBX,S8/L.1-2
+play,3,1,russa002,30,BBBB,W.2-3;1-2
+play,3,1,lackj001,22,CBBFS,K
+play,3,1,fowld001,12,BCFFS,K
+play,3,1,heywj001,01,SX,S9/L.3-H;2-H;1-2
+play,3,1,zobrb001,22,B*BCSFFX,5/P
+play,4,0,sches001,11,SBX,9/L
+play,4,0,dejei002,02,CSC,K
+play,4,0,barnt001,22,CBBCFX,53/G
+play,4,1,rizza001,00,,NP
+sub,sampk001,"Keyvius Sampson",0,9,1
+play,4,1,rizza001,22,.BFCBFC,K
+play,4,1,bryak001,20,BBX,HR/7/L
+play,4,1,montm001,31,CBBBB,W
+play,4,1,solej001,00,X,S7/L.1-2
+play,4,1,russa002,32,CBC*BBX,36(1)/FO/G.2-3
+play,4,1,lackj001,00,B,WP.3-H(NR);1-2
+play,4,1,lackj001,31,B.BBCB,W
+play,4,1,fowld001,22,BBSCX,6/P
+play,5,0,sampk001,12,CFBS,K
+play,5,0,hamib001,01,CX,8/L
+play,5,0,suare001,02,CCFFS,K
+play,5,1,heywj001,30,BBBB,W
+play,5,1,zobrb001,12,CC*BB,WP.1-2
+play,5,1,zobrb001,22,CC*BB.FC,K
+play,5,1,rizza001,00,X,4/P
+play,5,1,bryak001,11,BCX,8/F
+play,6,0,vottj001,02,CCFFC,K
+play,6,0,philb001,00,X,S7/L
+play,6,0,brucj001,32,BCBFBFX,46(1)3/GDP
+play,6,1,montm001,00,,NP
+sub,woodb004,"Blake Wood",0,9,1
+play,6,1,montm001,32,.CBFBBX,53/G
+play,6,1,solej001,31,SBBBB,W
+play,6,1,russa002,00,X,46(1)/FO/G
+play,6,1,lackj001,22,BCFBC,K
+play,7,0,sches001,11,CBX,T8/L+
+play,7,0,dejei002,00,X,63/G.3-H
+play,7,0,barnt001,00,X,S8/G
+play,7,0,woodb004,00,,NP
+sub,holtt001,"Tyler Holt",0,9,11
+play,7,0,holtt001,22,.BCFBT,K
+play,7,0,hamib001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,7,0,hamib001,12,.BFFX,3/L
+play,7,1,fowld001,00,,NP
+sub,ohler001,"Ross Ohlendorf",0,9,1
+play,7,1,fowld001,22,.CBBSS,K
+play,7,1,heywj001,01,CX,7/F
+play,7,1,zobrb001,00,X,8/L
+play,8,0,suare001,00,,NP
+sub,szczm001,"Matt Szczur",1,7,7
+play,8,0,suare001,00,,NP
+sub,richc002,"Clayton Richard",1,9,1
+play,8,0,suare001,22,..CFBFBX,S9/G+
+play,8,0,vottj001,21,CBBX,64(1)3/GDP
+play,8,0,philb001,11,FBX,13/G
+play,8,1,rizza001,00,,NP
+sub,cingt001,"Tony Cingrani",0,9,1
+play,8,1,rizza001,12,.BCFX,43/G
+play,8,1,bryak001,32,BFBFFFFBB,W
+play,8,1,montm001,22,*BC*BFT,K
+play,8,1,szczm001,11,SBX,5/P5F
+play,9,0,brucj001,00,,NP
+sub,ramin001,"Neil Ramirez",1,9,1
+play,9,0,brucj001,00,.X,6/P
+play,9,0,sches001,20,BBX,5/P
+play,9,0,dejei002,32,FBFBFFBB,W
+play,9,0,barnt001,01,>F>X,8/F
+data,er,simoa001,5
+data,er,strad003,2
+data,er,sampk001,2
+data,er,woodb004,0
+data,er,ohler001,0
+data,er,cingt001,0
+data,er,lackj001,2
+data,er,cahit001,0
+data,er,richc002,0
+data,er,ramin001,0
+id,CHN201604140
+version,2
+info,visteam,CIN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/04/14
+info,number,0
+info,starttime,7:05PM
+info,daynight,night
+info,usedh,false
+info,umphome,onorb901
+info,ump1b,porta901
+info,ump2b,tumpj901
+info,ump3b,kellj901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,seipb701
+info,temp,45
+info,winddir,tocf
+info,windspeed,8
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,187
+info,attendance,34898
+info,wp,hammj002
+info,lp,igler001
+info,save,
+start,hamib001,"Billy Hamilton",0,1,8
+start,suare001,"Eugenio Suarez",0,2,6
+start,vottj001,"Joey Votto",0,3,3
+start,philb001,"Brandon Phillips",0,4,4
+start,brucj001,"Jay Bruce",0,5,9
+start,duvaa001,"Adam Duvall",0,6,7
+start,pachj001,"Jordan Pacheco",0,7,5
+start,barnt001,"Tucker Barnhart",0,8,2
+start,igler001,"Raisel Iglesias",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,zobrb001,"Ben Zobrist",1,3,4
+start,rizza001,"Anthony Rizzo",1,4,3
+start,bryak001,"Kris Bryant",1,5,7
+start,lastt001,"Tommy La Stella",1,6,5
+start,montm001,"Miguel Montero",1,7,2
+start,russa002,"Addison Russell",1,8,6
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,hamib001,32,BFFFBBFB,W
+play,1,0,suare001,00,X,4/P
+play,1,0,vottj001,10,B1,PO1(13)
+play,1,0,vottj001,11,B1.TX,S7/G
+play,1,0,philb001,01,1SX,8/F
+play,1,1,fowld001,20,BBX,S9/L
+play,1,1,heywj001,32,B1FCBB>X,63/G.1-2
+play,1,1,zobrb001,32,*BBBCCFX,9/L/DP.2X2(96)
+play,2,0,brucj001,01,SX,7/F
+play,2,0,duvaa001,22,CBFBS,K
+play,2,0,pachj001,31,FBBBX,D7/G
+play,2,0,barnt001,01,SX,4/L
+play,2,1,rizza001,20,BBX,7/F
+play,2,1,bryak001,32,BCBBSX,HR/78/F
+play,2,1,lastt001,22,CSFFBBX,9/F
+play,2,1,montm001,32,BBSFBC,K
+play,3,0,igler001,01,FX,43/G
+play,3,0,hamib001,12,BMCX,43/G-
+play,3,0,suare001,02,CSS,K
+play,3,1,russa002,31,BCBBX,63/G
+play,3,1,hammj002,00,X,E4/G
+play,3,1,fowld001,00,X,S1/BG.1-2
+play,3,1,heywj001,01,CX,46(1)/FO/G.2-3
+play,3,1,zobrb001,30,*BBBB,W.1-2
+play,3,1,rizza001,12,BCFS,K
+play,4,0,vottj001,32,BBBCFFB,W
+play,4,0,philb001,00,X,4/P
+play,4,0,brucj001,32,CFBB+1B>B,W.1-2
+play,4,0,duvaa001,10,BX,64(1)/FO/G.2-3
+play,4,0,pachj001,12,BST1X,8/F
+play,4,1,bryak001,01,CX,S7/F-
+play,4,1,lastt001,22,11>FBS1FBX,7/L
+play,4,1,montm001,10,B>B,CS2(26)
+play,4,1,montm001,32,B>B.BCFFX,43/G
+play,5,0,barnt001,10,BX,S8/G+
+play,5,0,igler001,00,X,36(1)/FO/G
+play,5,0,hamib001,32,BBBCCB,W.1-2
+play,5,0,suare001,01,FX,7/F
+play,5,0,vottj001,10,BX,3/L+
+play,5,1,russa002,21,BSBX,S8/G
+play,5,1,hammj002,10,BX,D9/L+.1-H
+play,5,1,fowld001,32,BFBFFFBB,W
+play,5,1,heywj001,01,FX,43/G.2-3;1-2
+play,5,1,zobrb001,01,FX,8/F/SF.3-H;2-3
+play,5,1,rizza001,02,CFFFX,63/G
+play,6,0,philb001,21,BBCX,63/G+
+play,6,0,brucj001,22,MFBBX,D7/L
+play,6,0,duvaa001,12,BSFFFX,8/F
+play,6,0,pachj001,02,CCS,K23
+play,6,1,bryak001,00,,NP
+sub,woodb004,"Blake Wood",0,9,1
+play,6,1,bryak001,22,.BCCBX,3/G+
+play,6,1,lastt001,22,FSBBX,43/G
+play,6,1,montm001,32,BCSBFFBX,S7/G
+play,6,1,russa002,22,CSBFBX,S7/L+.1-2
+play,6,1,hammj002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,6,1,szczm001,22,.BSBSX,8/F
+play,7,0,barnt001,00,,NP
+sub,bryak001,"Kris Bryant",1,5,5
+play,7,0,barnt001,00,,NP
+sub,woodt004,"Travis Wood",1,6,1
+play,7,0,barnt001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,7
+play,7,0,barnt001,32,...CBBFBFC,K
+play,7,0,woodb004,00,,NP
+sub,holtt001,"Tyler Holt",0,9,11
+play,7,0,holtt001,10,.BX,8/L+
+play,7,0,hamib001,11,FBX,7/F
+play,7,1,fowld001,00,,NP
+sub,cothc001,"Caleb Cotham",0,9,1
+play,7,1,fowld001,22,.CBSFFBS,K
+play,7,1,heywj001,12,CBFX,5/P
+play,7,1,zobrb001,00,X,7/F
+play,8,0,suare001,00,,NP
+sub,strop001,"Pedro Strop",1,6,1
+play,8,0,suare001,22,.CCBBX,53/G
+play,8,0,vottj001,11,CBX,43/G
+play,8,0,philb001,02,FFS,K
+play,8,1,rizza001,00,,NP
+sub,hoovj002,"J.J. Hoover",0,9,1
+play,8,1,rizza001,20,.BBX,7/F
+play,8,1,bryak001,32,SCBBBFB,W
+play,8,1,strop001,00,,NP
+sub,solej001,"Jorge Soler",1,6,11
+play,8,1,solej001,32,.CSB*BFFBB,W.1-2
+play,8,1,montm001,10,BX,S9/F-.2-3;1-2
+play,8,1,russa002,00,X,S9/L.3-H;2-3;1-2
+play,8,1,szczm001,30,BBBB,W.3-H;2-3;1-2
+play,8,1,fowld001,21,CBBX,S9/G.3-H;2-H;1-3
+play,8,1,heywj001,00,,NP
+sub,diazj005,"Jumbo Diaz",0,9,1
+play,8,1,heywj001,00,.X,9/F.3-H(UR)(E9/TH)(NR);1-2
+play,8,1,zobrb001,32,CFFBFFBBS,K
+play,9,0,brucj001,00,,NP
+sub,grimj002,"Justin Grimm",1,6,1
+play,9,0,brucj001,21,.BCBX,S9/G+
+play,9,0,duvaa001,21,BBFX,D7/L+.1-3
+play,9,0,pachj001,22,F*BBFX,8/F-
+play,9,0,barnt001,01,CX,63/G.3-H;2-3
+play,9,0,diazj005,00,,NP
+sub,sches001,"Scott Schebler",0,9,11
+play,9,0,sches001,22,.BC*BCC,K
+data,er,igler001,3
+data,er,woodb004,0
+data,er,cothc001,0
+data,er,hoovj002,4
+data,er,diazj005,0
+data,er,hammj002,0
+data,er,woodt004,0
+data,er,strop001,0
+data,er,grimj002,1
+id,CHN201604150
+version,2
+info,visteam,COL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/04/15
+info,number,0
+info,starttime,1:19PM
+info,daynight,day
+info,usedh,false
+info,umphome,hirsj901
+info,ump1b,welkb901
+info,ump2b,carav901
+info,ump3b,fagac901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,52
+info,winddir,rtol
+info,windspeed,8
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,179
+info,attendance,34437
+info,wp,bettc001
+info,lp,hendk001
+info,save,
+start,lemad001,"DJ LeMahieu",0,1,4
+start,stort001,"Trevor Story",0,2,6
+start,gonzc001,"Carlos Gonzalez",0,3,9
+start,arenn001,"Nolan Arenado",0,4,5
+start,parrg001,"Gerardo Parra",0,5,8
+start,rabur001,"Ryan Raburn",0,6,7
+start,paulb001,"Ben Paulsen",0,7,3
+start,woltt001,"Tony Wolters",0,8,2
+start,bettc001,"Chad Bettis",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,zobrb001,"Ben Zobrist",1,3,4
+start,rizza001,"Anthony Rizzo",1,4,3
+start,bryak001,"Kris Bryant",1,5,5
+start,solej001,"Jorge Soler",1,6,7
+start,montm001,"Miguel Montero",1,7,2
+start,russa002,"Addison Russell",1,8,6
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,lemad001,02,CCX,7/L
+play,1,0,stort001,32,CBFBBFFX,63/G
+play,1,0,gonzc001,12,CBSX,63/G
+play,1,1,fowld001,22,CBFBC,K
+play,1,1,heywj001,32,FBBSBB,W
+play,1,1,zobrb001,32,BCBSB>X,8/F-
+play,1,1,rizza001,12,LBCX,7/L
+play,2,0,arenn001,01,CX,S5/G
+com,"$originally scored as E1, changed to single on 05-04-2016;"
+com,"his run is now earned"
+play,2,0,parrg001,02,FFS,K
+play,2,0,rabur001,00,X,S8/G+.1-3;B-2(TH)
+play,2,0,paulb001,01,FX,S8/L.3-H;2-3
+play,2,0,woltt001,10,BX,6/L
+play,2,0,bettc001,02,CCFX,43/G
+play,2,1,bryak001,32,BBCSBX,S9/G+
+play,2,1,solej001,22,CBF*BX,9/F
+play,2,1,montm001,02,CFS,K
+play,2,1,russa002,01,S>S,CS2(24)
+play,3,0,lemad001,12,CFBX,53/G
+play,3,0,stort001,02,CCFS,K
+play,3,0,gonzc001,00,X,1/G-
+play,3,1,russa002,10,BX,53/G
+play,3,1,hendk001,02,CFFC,K
+play,3,1,fowld001,31,CBBBB,W
+play,3,1,heywj001,12,BSSX,4/P-
+play,4,0,arenn001,12,CBFX,163/G
+play,4,0,parrg001,02,LFFX,43/G
+play,4,0,rabur001,01,CX,S9/L
+play,4,0,paulb001,00,X,8/L
+play,4,1,zobrb001,11,CBX,3/L
+play,4,1,rizza001,21,CBBX,8/F
+play,4,1,bryak001,12,FCBX,9/F-
+play,5,0,woltt001,12,CCBS,K
+play,5,0,bettc001,22,BCFBFX,E5/G-
+play,5,0,lemad001,22,LBBFS,K
+play,5,0,stort001,00,X,3/P
+play,5,1,solej001,32,BFCFFBBB,W
+play,5,1,montm001,10,B1X,8/F
+play,5,1,russa002,20,*BBX,S1/G-.1-3(E1/TH)
+play,5,1,hendk001,01,LX,FC3/BG.3XH(32);1-2
+play,5,1,fowld001,31,S*BBBX,7/F
+play,6,0,gonzc001,12,CBSX,S7/L
+play,6,0,arenn001,01,FX,S1/BG.1-2
+play,6,0,parrg001,00,X,S8/G.2-H;1-3
+play,6,0,rabur001,11,1F1BX,64(1)3/GDP.3-H
+play,6,0,paulb001,22,FBSBS,K
+play,6,1,heywj001,22,CSBFBC,K
+play,6,1,zobrb001,02,FCX,43/G
+play,6,1,rizza001,20,BBX,S3/G
+play,6,1,bryak001,11,SBX,64(1)/FO/G
+play,7,0,woltt001,12,CBSFX,S7/L-
+play,7,0,bettc001,00,,NP
+sub,barnb002,"Brandon Barnes",0,9,11
+play,7,0,barnb002,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,7,0,barnb002,01,..1M1X,S5/BG.1-H(UR)(E5/TH)(NR);B-2
+play,7,0,lemad001,02,FFFFFS,K
+play,7,0,stort001,20,BB2B,PB.2-3
+play,7,0,stort001,31,BB2B.CX,53/G
+play,7,0,gonzc001,30,IIII,IW
+play,7,0,arenn001,11,BFX,13/G
+play,7,1,solej001,00,,NP
+sub,qualc001,"Chad Qualls",0,6,1
+play,7,1,solej001,00,,NP
+sub,parrg001,"Gerardo Parra",0,5,7
+play,7,1,solej001,00,,NP
+sub,barnb002,"Brandon Barnes",0,9,8
+play,7,1,solej001,32,...SBCFBBX,S7/L
+play,7,1,montm001,31,BC*BBB,W.1-2
+play,7,1,russa002,10,BX,8/F.2-3
+play,7,1,cahit001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,7,1,lastt001,11,.BFX,36(1)/FO/G.3-H
+play,7,1,fowld001,20,BBX,43/G
+play,8,0,parrg001,00,,NP
+sub,richc002,"Clayton Richard",1,9,1
+play,8,0,parrg001,21,.BFBX,S6/G.B-2(E6/TH)
+play,8,0,qualc001,00,,NP
+sub,adamc001,"Cristhian Adames",0,6,11
+play,8,0,adamc001,00,.*B,SB3
+play,8,0,adamc001,22,.*B.FFBS,K
+play,8,0,paulb001,00,,NP
+sub,reynm001,"Mark Reynolds",0,7,11
+play,8,0,reynm001,30,.IIII,IW
+play,8,0,woltt001,01,MB,WP.1-2
+play,8,0,woltt001,11,MB,NP
+com,"umpchange,8,ump3b,carav901"
+com,"umpchange,8,ump2b,(None)"
+com,"$HP umpire John Hirschbeck was struck on the throat by"
+com,"a foul ball; 3B umpire Clint Fagan left to change into"
+com,"his plate gear"
+play,8,0,woltt001,22,MB.FFFB+3FX,E3/G.3-H(NR)(UR);2-3
+com,"$originally scored as fielder's choice, changed to error"
+com,"on 04-28-2016, removes RBI and makes 2 runs unearned"
+play,8,0,barnb002,00,,NP
+sub,ramin001,"Neil Ramirez",1,9,1
+play,8,0,barnb002,00,,NP
+com,"umpchange,8,umphome,fagac901"
+com,"$HP umpire John Hirschbeck left the game and was"
+com,"replaced by Clint Fagan"
+play,8,0,barnb002,10,..*B1>B,SB2
+play,8,0,barnb002,30,..*B1>B.BB,W
+play,8,0,lemad001,11,C*BX,64(1)/FO/G.3-H(UR);2-3
+play,8,0,stort001,01,C1>S,SB2
+play,8,0,stort001,02,C1>S.C,K
+play,8,1,heywj001,00,,NP
+sub,logab001,"Boone Logan",0,2,1
+play,8,1,heywj001,00,,NP
+sub,adamc001,"Cristhian Adames",0,6,6
+play,8,1,heywj001,00,,NP
+sub,reynm001,"Mark Reynolds",0,7,3
+play,8,1,heywj001,11,...BCX,13/G-
+play,8,1,zobrb001,12,CSBX,13/G
+play,8,1,rizza001,22,BCSBX,63/G
+play,9,0,gonzc001,12,BCSFFX,S7/L-
+play,9,0,arenn001,00,X,3/P3F
+play,9,0,parrg001,00,X,3(B)3636(1)/GDP
+play,9,1,bryak001,00,,NP
+sub,millj006,"Justin Miller",0,2,1
+play,9,1,bryak001,02,.CFC,K
+play,9,1,solej001,02,CSC,K
+play,9,1,montm001,12,CFBFFFFS,K
+data,er,bettc001,0
+data,er,qualc001,1
+data,er,logab001,0
+data,er,millj006,0
+data,er,hendk001,3
+data,er,cahit001,0
+data,er,richc002,0
+data,er,ramin001,0
+id,CHN201604160
+version,2
+info,visteam,COL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/04/16
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,welkb901
+info,ump1b,carav901
+info,ump2b,fagac901
+info,ump3b,hudsm901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,54
+info,winddir,rtol
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,159
+info,attendance,41702
+info,wp,arrij001
+info,lp,bergc001
+info,save,
+start,adamc001,"Cristhian Adames",0,1,4
+start,stort001,"Trevor Story",0,2,6
+start,gonzc001,"Carlos Gonzalez",0,3,9
+start,arenn001,"Nolan Arenado",0,4,5
+start,parrg001,"Gerardo Parra",0,5,8
+start,reynm001,"Mark Reynolds",0,6,3
+start,rabur001,"Ryan Raburn",0,7,7
+start,garnd001,"Dustin Garneau",0,8,2
+start,bergc001,"Christian Bergman",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,solej001,"Jorge Soler",1,4,7
+start,baezj001,"Javier Baez",1,5,4
+start,russa002,"Addison Russell",1,6,6
+start,szczm001,"Matt Szczur",1,7,9
+start,rossd001,"David Ross",1,8,2
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,adamc001,02,FLS,K
+play,1,0,stort001,12,CSBFT,K
+play,1,0,gonzc001,12,SSBFS,K
+play,1,1,fowld001,22,BSBCX,13/G
+play,1,1,bryak001,22,CCBBC,K
+play,1,1,rizza001,02,CSS,K
+play,2,0,arenn001,10,BX,6/P
+play,2,0,parrg001,22,CBBSX,13/G-
+play,2,0,reynm001,01,SX,S4/G
+play,2,0,rabur001,20,*BBX,4/P
+play,2,1,solej001,00,X,S7/G+
+play,2,1,baezj001,10,*B1X,S5/G-.1-2
+play,2,1,russa002,10,BX,64(1)3/GDP.2-3
+play,2,1,szczm001,11,BFX,9/F
+play,3,0,garnd001,32,BBCBCFX,D9/L
+play,3,0,bergc001,21,*BBLX,43/G.2-3
+play,3,0,adamc001,02,CSFX,3/G
+play,3,0,stort001,12,FSBS,K23
+play,3,1,rossd001,12,CBFFX,9/F
+play,3,1,arrij001,00,X,9/F
+play,3,1,fowld001,31,BBFBB,W
+play,3,1,bryak001,32,FSBFBFB>C,K
+play,4,0,gonzc001,12,BCFX,S7/L
+play,4,0,arenn001,11,SBX,8/L
+play,4,0,parrg001,22,BF1BF>S,K+CS2(26)/DP
+play,4,1,rizza001,00,X,HR/9/F
+play,4,1,solej001,00,X,HR/8/F
+play,4,1,baezj001,32,CBSBBFS,K
+play,4,1,russa002,02,CCX,9/F
+play,4,1,szczm001,00,X,7/L
+play,5,0,reynm001,12,BCCC,K
+play,5,0,rabur001,12,BCFFS,K
+play,5,0,garnd001,01,CX,63/G
+play,5,1,rossd001,02,FCS,K
+play,5,1,arrij001,02,CFFFFS,K
+play,5,1,fowld001,02,CSFFC,K
+play,6,0,bergc001,00,,NP
+sub,barnb002,"Brandon Barnes",0,9,11
+play,6,0,barnb002,00,.X,43/G
+play,6,0,adamc001,32,CBFBBX,8/F-
+play,6,0,stort001,32,BFCBBS,K
+play,6,1,bryak001,00,,NP
+sub,haled001,"David Hale",0,9,1
+play,6,1,bryak001,00,.X,9/F
+play,6,1,rizza001,32,BCBBF*B,W
+play,6,1,solej001,32,BBFBFX,9/F
+play,6,1,baezj001,01,1S>S,SB2
+play,6,1,baezj001,12,1S>S.*BFS,K
+play,7,0,gonzc001,10,BX,43/G
+play,7,0,arenn001,00,X,4/P
+play,7,0,parrg001,01,CX,S1/BG
+play,7,0,reynm001,02,FC>B,SB2
+play,7,0,reynm001,22,FC>B.FBX,S/BR/G.2X3(6)
+play,7,1,russa002,01,FX,53/BG
+play,7,1,szczm001,12,CFBX,S7/L-
+play,7,1,rossd001,22,1BF1P1F>B,SB2
+play,7,1,rossd001,32,1BF1P1F>B.B,W
+play,7,1,arrij001,10,B2X,8/L.2-3
+play,7,1,fowld001,21,FBBX,HR/89/L.3-H;1-H
+play,7,1,bryak001,12,CBFFX,S5/G-
+play,7,1,rizza001,00,,NP
+sub,gurkj001,"Jason Gurka",0,6,1
+play,7,1,rizza001,00,,NP
+sub,paulb001,"Ben Paulsen",0,9,3
+play,7,1,rizza001,32,..BBCBF>C,K
+play,8,0,rabur001,32,BBFBFFB,W
+play,8,0,garnd001,00,X,54(1)3/GDP
+play,8,0,paulb001,00,X,8/F
+play,8,1,solej001,01,CX,43/G
+play,8,1,baezj001,02,SFFFX,D8/L
+play,8,1,russa002,10,B22,PO2(E1).2-3
+play,8,1,russa002,32,B22.*BSF*BFB,W
+play,8,1,szczm001,31,BBBCB,W.1-2
+play,8,1,rossd001,00,X,9/F/SF.3-H;2-3
+play,8,1,arrij001,12,BSCFS,K
+play,9,0,adamc001,00,,NP
+sub,heywj001,"Jason Heyward",1,4,9
+play,9,0,adamc001,00,,NP
+sub,szczm001,"Matt Szczur",1,7,7
+play,9,0,adamc001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,9,0,adamc001,11,...CBX,53/G
+play,9,0,stort001,12,CFFBX,D9/L
+play,9,0,gonzc001,00,X,HR/78/L.2-H
+play,9,0,arenn001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,9,0,arenn001,22,.CBCBS,K
+play,9,0,parrg001,22,BBSFX,13/G-
+data,er,bergc001,2
+data,er,haled001,3
+data,er,gurkj001,1
+data,er,arrij001,0
+data,er,woodt004,2
+data,er,strop001,0
+id,CHN201604170
+version,2
+info,visteam,COL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/04/17
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,carav901
+info,ump1b,fagac901
+info,ump2b,hudsm901
+info,ump3b,welkb901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,58
+info,winddir,fromrf
+info,windspeed,7
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,158
+info,attendance,41678
+info,wp,chatt001
+info,lp,lestj001
+info,save,mcgej001
+start,lemad001,"DJ LeMahieu",0,1,4
+start,stort001,"Trevor Story",0,2,6
+start,gonzc001,"Carlos Gonzalez",0,3,9
+start,arenn001,"Nolan Arenado",0,4,5
+start,parrg001,"Gerardo Parra",0,5,7
+start,reynm001,"Mark Reynolds",0,6,3
+start,barnb002,"Brandon Barnes",0,7,8
+start,woltt001,"Tony Wolters",0,8,2
+start,chatt001,"Tyler Chatwood",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,zobrb001,"Ben Zobrist",1,3,4
+start,rizza001,"Anthony Rizzo",1,4,3
+start,bryak001,"Kris Bryant",1,5,5
+start,solej001,"Jorge Soler",1,6,7
+start,baezj001,"Javier Baez",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,lemad001,22,BFFBS,K
+play,1,0,stort001,10,BX,S7/L+
+play,1,0,gonzc001,21,*BBF>B,CS2(26)
+play,1,0,gonzc001,32,*BBF>B.TX,63/G
+play,1,1,fowld001,00,X,53/G-
+play,1,1,heywj001,32,BCCBFBFS,K
+play,1,1,zobrb001,10,BX,7/L
+play,2,0,arenn001,21,CBBX,8/L
+play,2,0,parrg001,12,CBCS,K.BX1(2E3)
+play,2,0,reynm001,02,FCS,K
+play,2,0,barnb002,00,>C,CS2(24)
+play,2,1,rizza001,01,CX,8/F
+play,2,1,bryak001,22,FFBBX,3/P
+play,2,1,solej001,11,CBX,13/G-
+play,3,0,barnb002,01,FX,7/F
+play,3,0,woltt001,11,CBX,S9/L
+play,3,0,chatt001,11,CBX,S7/L.1-2
+play,3,0,lemad001,01,FX,6(1)3/GDP
+play,3,1,baezj001,32,FBBFBS,K
+play,3,1,rossd001,22,BSFBC,K
+play,3,1,lestj001,32,BBSSBC,K
+play,4,0,stort001,12,BSFS,K
+play,4,0,gonzc001,32,CCBBBS,K
+play,4,0,arenn001,00,X,HR/7/F
+play,4,0,parrg001,11,BSX,31/G-
+play,4,1,fowld001,22,BCFBC,K
+play,4,1,heywj001,01,CX,13/G
+play,4,1,zobrb001,01,CX,7/F
+play,5,0,reynm001,00,X,53/G
+play,5,0,barnb002,22,BCBSC,K
+play,5,0,woltt001,00,X,1/BP
+play,5,1,rizza001,10,BX,9/F
+play,5,1,bryak001,12,CFFFBS,K
+play,5,1,solej001,32,CBBCBB,W
+play,5,1,baezj001,22,BFFBFFX,S7/L+.1-2
+play,5,1,rossd001,10,BX,64(1)/FO/G
+play,6,0,chatt001,12,CBSS,K
+play,6,0,lemad001,22,BCBFC,K
+play,6,0,stort001,32,BFFBBFFB,W
+play,6,0,gonzc001,12,BCC>B,SB2
+play,6,0,gonzc001,22,BCC>B.X,6/L
+play,6,1,lestj001,20,BBX,D9/L+
+play,6,1,fowld001,22,BCLBX,7/F
+play,6,1,heywj001,22,BBC2CS,K
+play,6,1,zobrb001,32,CBBFBFX,8/F
+play,7,0,arenn001,02,CFX,4/L
+play,7,0,parrg001,22,SSBBL,K/BF
+play,7,0,reynm001,22,BBCCS,K
+play,7,1,rizza001,12,CBFFX,4/P
+play,7,1,bryak001,12,FBFX,53/G
+play,7,1,solej001,00,X,8/F
+play,8,0,barnb002,01,CX,13/BG
+com,"$Jon Lester threw his glove with the ball to 1B"
+play,8,0,woltt001,32,BBBCCB,W
+play,8,0,chatt001,00,,NP
+sub,rabur001,"Ryan Raburn",0,9,11
+play,8,0,rabur001,00,,NP
+sub,warra001,"Adam Warren",1,9,1
+play,8,0,rabur001,22,..1SBS+1F1FBX,53/G-.1-2
+play,8,0,lemad001,12,CFBT,K
+play,8,1,baezj001,00,,NP
+sub,castm002,"Miguel Castro",0,9,1
+play,8,1,baezj001,10,.BX,43/G
+play,8,1,rossd001,00,,NP
+sub,montm001,"Miguel Montero",1,8,11
+play,8,1,montm001,32,.BBCSBS,K
+play,8,1,warra001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,8,1,lastt001,10,.BX,31/G
+play,9,0,stort001,00,,NP
+sub,montm001,"Miguel Montero",1,8,2
+play,9,0,stort001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,9,0,stort001,12,..BCCS,K
+play,9,0,gonzc001,32,SBSBBS,K
+play,9,0,arenn001,32,FBBCBX,HR/78/F
+play,9,0,parrg001,02,CFS,K
+play,9,1,fowld001,00,,NP
+sub,mcgej001,"Jake McGee",0,9,1
+play,9,1,fowld001,00,.X,63/G+
+play,9,1,heywj001,11,CBX,D9/L+
+play,9,1,zobrb001,11,BFX,7/F
+play,9,1,rizza001,11,BFH,HP
+play,9,1,bryak001,00,,NP
+sub,szczm001,"Matt Szczur",1,4,12
+play,9,1,bryak001,12,F.BSS,K
+data,er,chatt001,0
+data,er,castm002,0
+data,er,mcgej001,0
+data,er,lestj001,1
+data,er,warra001,0
+data,er,grimj002,1
+id,CHN201604260
+version,2
+info,visteam,MIL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/04/26
+info,number,0
+info,starttime,7:08PM
+info,daynight,night
+info,usedh,false
+info,umphome,vanol901
+info,ump1b,marqa901
+info,ump2b,guccc901
+info,ump3b,rackd901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,40
+info,winddir,fromrf
+info,windspeed,16
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,189
+info,attendance,35861
+info,wp,warra001
+info,lp,nelsj004
+info,save,rondh001
+start,santd002,"Domingo Santana",0,1,9
+start,villj001,"Jonathan Villar",0,2,6
+start,lucrj001,"Jonathan Lucroy",0,3,2
+start,cartc002,"Chris Carter",0,4,3
+start,nieuk001,"Kirk Nieuwenhuis",0,5,8
+start,hilla001,"Aaron Hill",0,6,5
+start,florr003,"Ramon Flores",0,7,7
+start,rivey001,"Yadiel Rivera",0,8,4
+start,nelsj004,"Jimmy Nelson",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,solej001,"Jorge Soler",1,6,7
+start,russa002,"Addison Russell",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,santd002,12,CCBT,K
+play,1,0,villj001,00,X,43/G
+play,1,0,lucrj001,22,CBCBX,43/G
+play,1,1,fowld001,21,CBBX,153/G
+play,1,1,heywj001,22,BSSBC,K
+play,1,1,bryak001,32,FBSFBBFS,K
+play,2,0,cartc002,32,CCBBBB,W
+play,2,0,nieuk001,22,BCBSX,D8/L.1-3
+play,2,0,hilla001,21,BBCX,7/F/SF.3-H
+play,2,0,florr003,11,BCX,63/G.2-3
+play,2,0,rivey001,02,CCC,K
+play,2,1,rizza001,32,CBBFFFBX,153/G
+play,2,1,zobrb001,30,BBBB,W
+play,2,1,solej001,22,F1BBFF1C,K
+play,2,1,russa002,12,BFSX,43/G
+play,3,0,nelsj004,12,BCSC,K
+play,3,0,santd002,31,BBBCX,63/G
+play,3,0,villj001,12,CCBX,43/G
+play,3,1,rossd001,01,MX,63/G
+play,3,1,hendk001,12,CCFBC,K
+play,3,1,fowld001,12,BCFT,K
+play,4,0,lucrj001,12,CFBX,9/F
+play,4,0,cartc002,22,BCSBX,S8/G
+play,4,0,nieuk001,01,FX,46(1)3/GDP
+play,4,1,heywj001,31,CBBBX,43/G
+play,4,1,bryak001,00,X,D7/G
+play,4,1,rizza001,22,CFBBS,K
+play,4,1,zobrb001,22,CFB*BX,7/F
+play,5,0,hilla001,32,BBBCCC,K
+play,5,0,florr003,01,FX,53/G
+play,5,0,rivey001,22,BCBCFX,13/G
+play,5,1,solej001,32,BBCSBFB,W
+play,5,1,russa002,00,X,S7/G.1-2
+play,5,1,rossd001,11,M*BX,14/BG/SH.2-3;1-2
+play,5,1,hendk001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,5,1,lastt001,31,.*BF*BBB,W
+play,5,1,fowld001,22,CBFFBX,8/F/SF.3-H;2-3;1-2
+play,5,1,heywj001,31,BBCBX,43/G
+play,6,0,nelsj004,00,,NP
+sub,warra001,"Adam Warren",1,9,1
+play,6,0,nelsj004,12,.CSBS,K
+play,6,0,santd002,22,BSFFBFFX,63/G
+play,6,0,villj001,32,BSSBFBFFX,13/G-
+play,6,1,bryak001,21,BCBX,E5/G
+play,6,1,rizza001,22,*BCF1*BFX,8/F
+play,6,1,zobrb001,32,CBF*BB>B,W.1-2
+play,6,1,solej001,00,,NP
+sub,torrc001,"Carlos Torres",0,9,1
+play,6,1,solej001,21,.SBBX,9/F
+play,6,1,russa002,10,BX,T8/L.2-H(UR);1-H(UR)
+play,6,1,rossd001,22,BFSBFC,K
+play,7,0,lucrj001,21,BBCX,8/F
+play,7,0,cartc002,32,SBBFBS,K
+play,7,0,nieuk001,22,CSBBC,K
+play,7,1,warra001,00,,NP
+sub,boyeb001,"Blaine Boyer",0,9,1
+play,7,1,warra001,00,,NP
+sub,baezj001,"Javier Baez",1,9,11
+play,7,1,baezj001,10,..BX,S8/L
+play,7,1,fowld001,01,L>C,SB2/MREV
+com,"replay,7,fowld001,CHN,vanol901,CHI11,,Y,M,CHN,A"
+com,"$when Javier Baez was called out at 2B, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was overturned by replay"
+play,7,1,fowld001,22,L>C.BBFC,K
+play,7,1,heywj001,11,SBX,7/F
+play,7,1,bryak001,30,BBBB,W
+play,7,1,rizza001,21,CBBX,D4/G.2-H;1-3
+play,7,1,zobrb001,21,CBBX,43/G
+play,8,0,hilla001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,8,0,hilla001,00,,NP
+sub,strop001,"Pedro Strop",1,6,1
+play,8,0,hilla001,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,8,0,hilla001,32,...BCFBBB,W
+play,8,0,florr003,00,B,WP.1-2
+play,8,0,florr003,22,B.CBCX,3/G.2-3
+play,8,0,rivey001,00,,NP
+sub,walsc001,"Colin Walsh",0,8,11
+play,8,0,walsc001,32,.B*BCSB*B,W
+play,8,0,boyeb001,00,,NP
+sub,braur002,"Ryan Braun",0,9,11
+play,8,0,braur002,00,.X,D9/L.3-H;1-H
+play,8,0,santd002,22,BSCFB>FS,K
+play,8,0,villj001,00,,NP
+sub,woodt004,"Travis Wood",1,6,1
+play,8,0,villj001,01,.SX,4/P
+play,8,1,woodt004,00,,NP
+sub,walsc001,"Colin Walsh",0,8,4
+play,8,1,woodt004,00,,NP
+sub,blazm001,"Michael Blazek",0,9,1
+play,8,1,woodt004,00,,NP
+sub,szczm001,"Matt Szczur",1,6,11
+play,8,1,szczm001,02,...CLFX,S7/L
+play,8,1,russa002,02,1F1F1X,64(1)/FO/G
+play,8,1,rossd001,12,CFBX,S9/L.1-2
+play,8,1,baezj001,12,BFSS,K
+play,8,1,fowld001,32,BCFBB>B,W.2-3;1-2
+play,8,1,heywj001,10,BX,31/G
+play,9,0,lucrj001,00,,NP
+sub,rondh001,"Hector Rondon",1,6,1
+play,9,0,lucrj001,32,.BBBCFT,K
+play,9,0,cartc002,12,BCFX,53/G
+play,9,0,nieuk001,21,BBCX,S9/G
+play,9,0,hilla001,02,FCX,7/F
+data,er,nelsj004,1
+data,er,torrc001,0
+data,er,boyeb001,1
+data,er,blazm001,0
+data,er,hendk001,1
+data,er,warra001,0
+data,er,strop001,2
+data,er,woodt004,0
+data,er,rondh001,0
+id,CHN201604280
+version,2
+info,visteam,MIL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/04/28
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,marqa901
+info,ump1b,guccc901
+info,ump2b,rackd901
+info,ump3b,vanol901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,45
+info,winddir,fromcf
+info,windspeed,12
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,225
+info,attendance,32734
+info,wp,arrij001
+info,lp,jungt001
+info,save,
+start,villj001,"Jonathan Villar",0,1,6
+start,presa001,"Alex Presley",0,2,9
+start,braur002,"Ryan Braun",0,3,7
+start,lucrj001,"Jonathan Lucroy",0,4,2
+start,cartc002,"Chris Carter",0,5,3
+start,nieuk001,"Kirk Nieuwenhuis",0,6,8
+start,hilla001,"Aaron Hill",0,7,5
+start,rivey001,"Yadiel Rivera",0,8,4
+start,jungt001,"Taylor Jungmann",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,7
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,lastt001,"Tommy La Stella",1,6,5
+start,russa002,"Addison Russell",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,villj001,22,BBCSX,S7/L-
+play,1,0,presa001,02,CF11X,7/F
+play,1,0,braur002,12,1SBF1>B,SB2
+play,1,0,braur002,32,1SBF1>B.*B*B,W
+play,1,0,lucrj001,10,B>C,SB3;SB2
+play,1,0,lucrj001,31,B>C.BBB,W
+play,1,0,cartc002,22,BCBFS,K
+play,1,0,nieuk001,32,BSF*BB>F>S,K
+play,1,1,fowld001,10,BX,S8/L-
+play,1,1,heywj001,01,F1X,2/P2F
+play,1,1,bryak001,00,1H,HP.1-2
+play,1,1,rizza001,31,FBBBB,W.2-3;1-2
+play,1,1,zobrb001,22,CBBFX,S9/G.3-H;2-H;1-3
+play,1,1,lastt001,20,BBX,5/P5F
+play,1,1,russa002,01,CX,63/G
+play,2,0,hilla001,02,CCX,43/G
+play,2,0,rivey001,01,CX,43/G
+play,2,0,jungt001,12,CCBC,K
+play,2,1,rossd001,32,CCBBBX,HR/78/L
+play,2,1,arrij001,32,BBBFFX,9/L
+play,2,1,fowld001,31,BCBBX,8/F
+play,2,1,heywj001,32,BCBBCX,8/F
+play,3,0,villj001,31,BSBBB,W
+play,3,0,presa001,02,CS1X,8/F
+play,3,0,braur002,11,11CBX,46(1)3/GDP
+play,3,1,bryak001,22,BSFFBFX,S8/L
+play,3,1,rizza001,31,BC1BBX,D9/L.1-H
+play,3,1,zobrb001,20,B*BX,31/L
+play,3,1,lastt001,02,CFX,D7/L.2-H
+play,3,1,russa002,02,CCFC,K
+play,3,1,rossd001,11,CBX,9/F
+play,4,0,lucrj001,32,CBBFFBB,W
+play,4,0,cartc002,12,CSBS,K
+play,4,0,nieuk001,32,FBFBBX,13/G-.1-2
+play,4,0,hilla001,22,BSF*BC,K
+play,4,1,arrij001,22,CBCBX,8/F
+play,4,1,fowld001,32,CBBBCC,K
+play,4,1,heywj001,30,BBBB,W
+play,4,1,bryak001,32,SB*BS1*BH,HP.1-2
+play,4,1,rizza001,32,SBBCB>B,W.2-3;1-2
+play,4,1,zobrb001,00,,NP
+sub,capuc001,"Chris Capuano",0,7,1
+play,4,1,zobrb001,00,,NP
+sub,pereh001,"Hernan Perez",0,9,5
+play,4,1,zobrb001,12,..*BFFX,8/F
+play,5,0,rivey001,00,,NP
+sub,baezj001,"Javier Baez",1,3,7
+play,5,0,rivey001,02,.FSS,K
+play,5,0,pereh001,22,CCFFBFBX,63/G-
+play,5,0,villj001,11,BFX,S7/L
+play,5,0,presa001,00,>B,SB2
+play,5,0,presa001,12,>B.FSX,D9/L.2-H
+play,5,0,braur002,00,X,43/G
+play,5,1,lastt001,32,BBCBTFB,W
+play,5,1,russa002,00,1,PO1(E1).1-2
+play,5,1,russa002,32,1.CSBBBFB,W
+play,5,1,rossd001,10,*BX,8/L.2-3
+play,5,1,arrij001,00,,NP
+sub,solej001,"Jorge Soler",1,9,11
+play,5,1,solej001,00,.B,WP.1-2
+play,5,1,solej001,32,.B.SF*BB*B,W
+play,5,1,fowld001,11,*BFX,64(1)/FO/G.3-H;2-3
+play,5,1,heywj001,12,CBFX,3/G
+play,6,0,lucrj001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,6,0,lucrj001,10,.BX,S8/L
+play,6,0,cartc002,22,CSB*BS,K
+play,6,0,nieuk001,22,F*BBFC,K
+play,6,0,capuc001,00,,NP
+sub,florr003,"Ramon Flores",0,7,11
+play,6,0,florr003,22,.BCF*BC,K
+play,6,1,baezj001,00,,NP
+sub,frees001,"Sam Freeman",0,7,1
+play,6,1,baezj001,02,.SSX,S6/G
+play,6,1,rizza001,20,B*BB,PB.1-2
+play,6,1,rizza001,30,B*BB.B,W
+play,6,1,zobrb001,22,CBCB>C,K+PO2(E4).2-3
+play,6,1,lastt001,32,BFBFBFB,W.1-2
+play,6,1,russa002,12,SFBFFX,64(1)/FO/G.3-H;2-3
+play,6,1,rossd001,31,SBBBB,W.1-2
+play,6,1,grimj002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,6,1,szczm001,22,.FS*B*BX,4/L
+play,7,0,rivey001,00,,NP
+sub,baezj001,"Javier Baez",1,3,5
+play,7,0,rivey001,00,,NP
+sub,cahit001,"Trevor Cahill",1,6,1
+play,7,0,rivey001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,7
+play,7,0,rivey001,32,...BCBFBFS,K
+play,7,0,pereh001,32,BBFBFX,S8/G
+play,7,0,villj001,22,FFF*B1B1>S,K+SB2.1-3(E2/TH)
+play,7,0,presa001,32,BCS*BBB,W
+play,7,0,braur002,11,CBX,4/P
+play,7,1,fowld001,00,X,3/G
+play,7,1,heywj001,01,CX,13/G-
+play,7,1,baezj001,30,BBBB,W
+play,7,1,rizza001,22,CBBCB,WP.1-2
+play,7,1,rizza001,32,CBBCB.C,K
+play,8,0,lucrj001,32,CFBFBFBFF*B,W
+play,8,0,cartc002,01,FX,4(1)3/GDP
+play,8,0,nieuk001,21,SBBX,E1/TH/G-
+play,8,0,frees001,00,,NP
+sub,walsc001,"Colin Walsh",0,7,11
+play,8,0,walsc001,31,.BC*BBB,W.1-2
+play,8,0,rivey001,00,,NP
+sub,strop001,"Pedro Strop",1,6,1
+play,8,0,rivey001,02,.CFS,K
+play,8,1,zobrb001,00,,NP
+sub,torrc001,"Carlos Torres",0,7,1
+play,8,1,zobrb001,00,.X,S9/L
+play,8,1,strop001,00,,NP
+sub,fedet001,"Tim Federowicz",1,6,11
+play,8,1,fedet001,32,.BCFBBX,9/F
+play,8,1,russa002,32,BBFBFFFFB,W.1-2
+play,8,1,rossd001,00,,NP
+sub,hammj002,"Jason Hammel",1,8,11
+play,8,1,hammj002,22,.BBSSS,K
+play,8,1,szczm001,01,FX,9/F
+play,9,0,pereh001,00,,NP
+sub,fedet001,"Tim Federowicz",1,6,2
+play,9,0,pereh001,00,,NP
+sub,ramin001,"Neil Ramirez",1,8,1
+play,9,0,pereh001,12,..FFFBFC,K
+play,9,0,villj001,11,BFX,D8/F
+play,9,0,presa001,01,CB,WP.2-3
+play,9,0,presa001,32,CB.FF*BFF*BX,9/F/SF.3-H
+play,9,0,braur002,01,FX,13/G
+data,er,jungt001,5
+data,er,capuc001,1
+data,er,frees001,1
+data,er,torrc001,0
+data,er,arrij001,1
+data,er,grimj002,0
+data,er,cahit001,0
+data,er,strop001,0
+data,er,ramin001,1
+id,CHN201604290
+version,2
+info,visteam,ATL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/04/29
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,buckc901
+info,ump1b,reynj901
+info,ump2b,gonzm901
+info,ump3b,culbf901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,44
+info,winddir,fromcf
+info,windspeed,10
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,158
+info,attendance,34007
+info,wp,strop001
+info,lp,johnj010
+info,save,
+start,markn001,"Nick Markakis",0,1,9
+start,castd001,"Daniel Castro",0,2,6
+start,freef001,"Freddie Freeman",0,3,3
+start,garca004,"Adonis Garcia",0,4,5
+start,franj004,"Jeff Francoeur",0,5,7
+start,flowt001,"Tyler Flowers",0,6,2
+start,aybae001,"Erick Aybar",0,7,4
+start,stubd001,"Drew Stubbs",0,8,8
+start,blaia001,"Aaron Blair",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,zobrb001,"Ben Zobrist",1,3,4
+start,rizza001,"Anthony Rizzo",1,4,3
+start,solej001,"Jorge Soler",1,5,7
+start,baezj001,"Javier Baez",1,6,5
+start,russa002,"Addison Russell",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,markn001,12,FBCS,K
+play,1,0,castd001,32,BFSBB*B,W
+play,1,0,freef001,01,F>B,CS2(26)
+play,1,0,freef001,12,F>B.SFS,K
+play,1,1,fowld001,30,BBBB,W
+play,1,1,heywj001,11,BC1X,46(1)/FO/G
+play,1,1,zobrb001,31,CB1B*BB,W.1-2
+play,1,1,rizza001,02,CF>X,3/G.2-3;1-2
+play,1,1,solej001,22,BFFBS,K
+play,2,0,garca004,01,FX,S8/G
+play,2,0,franj004,00,X,6/P
+play,2,0,flowt001,12,CBSC,K
+play,2,0,aybae001,12,L*BS>X,S4/G.1-3
+play,2,0,stubd001,32,SBBBC>S,K
+play,2,1,baezj001,12,SMBFFS,K
+play,2,1,russa002,30,BBBX,8/F
+play,2,1,rossd001,10,BX,5/P5F
+play,3,0,blaia001,02,CSC,K
+play,3,0,markn001,10,BX,5/L
+play,3,0,castd001,01,CX,8/F
+play,3,1,lestj001,01,CX,43/G
+play,3,1,fowld001,20,BBX,43/G
+play,3,1,heywj001,22,CSBBS,K
+play,4,0,freef001,30,BBBX,HR/89/F
+play,4,0,garca004,00,X,63/G
+play,4,0,franj004,22,SBBFFS,K
+play,4,0,flowt001,12,CBSC,K
+play,4,1,zobrb001,22,BCBCFFX,3/G
+play,4,1,rizza001,32,CBSBBX,7/L
+play,4,1,solej001,11,BFX,9/F
+play,5,0,aybae001,01,FX,34/BG
+play,5,0,stubd001,12,BCFC,K
+play,5,0,blaia001,12,BCCX,3/G-
+play,5,1,baezj001,20,BBX,D7/G+
+play,5,1,russa002,00,X,7/F
+play,5,1,rossd001,21,BCBX,S7/L.2-H
+play,5,1,lestj001,21,B1BCX,16(1)3/GDP
+play,6,0,markn001,10,BX,S7/L
+play,6,0,castd001,22,C*BP>FX,4/P
+play,6,0,freef001,01,FX,S7/L.1-2
+play,6,0,garca004,02,CFX,36(1)1/GDP
+play,6,1,fowld001,32,CBFBBFB,W
+play,6,1,heywj001,11,C1BX,4/P/DP.1X1(43)
+play,6,1,zobrb001,02,CCFFX,5/P
+play,7,0,franj004,11,BCX,S8/L
+play,7,0,flowt001,22,BCC*BB,WP.1-2
+play,7,0,flowt001,32,BCC*BB.B,W
+play,7,0,aybae001,01,CX,S1/BG.2-3;1-2
+play,7,0,stubd001,32,FFBBBFFS,K
+play,7,0,blaia001,00,,NP
+sub,petej002,"Jace Peterson",0,9,11
+play,7,0,petej002,12,.BSFC,K
+play,7,0,markn001,32,BFCBB>F>X,3/G
+play,7,1,rizza001,00,,NP
+sub,ogana001,"Alexi Ogando",0,9,1
+play,7,1,rizza001,32,.BBCBFB,W
+play,7,1,solej001,01,CX,S9/L.1-2
+play,7,1,baezj001,11,BLX,43/G-.2-3;1-2
+play,7,1,russa002,30,IIII,IW
+play,7,1,rossd001,00,X,46(1)3/GDP
+play,8,0,castd001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,8,0,castd001,00,,NP
+sub,szczm001,"Matt Szczur",1,5,7
+play,8,0,castd001,11,..BCX,63/G
+play,8,0,freef001,22,CBBFS,K
+play,8,0,garca004,02,CCFFS,K
+play,8,1,strop001,00,,NP
+sub,johnj010,"Jim Johnson",0,9,1
+play,8,1,strop001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,8,1,lastt001,31,..BFBBX,D7/F
+play,8,1,fowld001,01,SX,FC1/BG.2X3(15)
+play,8,1,heywj001,31,1*BB>F*B>B,W.1-2
+play,8,1,zobrb001,22,BCBFX,S9/L.2-3;1-2
+play,8,1,rizza001,00,,NP
+sub,oflae001,"Eric O'Flaherty",0,9,1
+play,8,1,rizza001,11,.BCX,S8/L.3-H;2-3;1-2
+play,8,1,szczm001,00,,NP
+sub,withc001,"Chris Withrow",0,9,1
+play,8,1,szczm001,01,.CX,HR/78/F.3-H;2-H;1-H
+play,8,1,baezj001,32,BBBCSB,W
+play,8,1,russa002,12,BS1CX,7/F
+play,8,1,rossd001,01,CX,8/F
+play,9,0,franj004,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,9,0,franj004,00,.X,9/F
+play,9,0,flowt001,12,FCBS,K
+play,9,0,aybae001,00,X,31/G
+data,er,blaia001,1
+data,er,ogana001,0
+data,er,johnj010,3
+data,er,oflae001,1
+data,er,withc001,1
+data,er,lestj001,1
+data,er,strop001,0
+data,er,rondh001,0
+id,CHN201605010
+version,2
+info,visteam,ATL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/01
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,reynj901
+info,ump1b,gonzm901
+info,ump2b,culbf901
+info,ump3b,buckc901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,44
+info,winddir,fromcf
+info,windspeed,14
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,184
+info,attendance,40164
+info,wp,vizca001
+info,lp,rondh001
+info,save,grilj001
+start,markn001,"Nick Markakis",0,1,9
+start,aybae001,"Erick Aybar",0,2,6
+start,freef001,"Freddie Freeman",0,3,3
+start,garca004,"Adonis Garcia",0,4,7
+start,johnk003,"Kelly Johnson",0,5,4
+start,flowt001,"Tyler Flowers",0,6,2
+start,petej002,"Jace Peterson",0,7,5
+start,tehej001,"Julio Teheran",0,8,1
+start,smitm007,"Mallex Smith",0,9,8
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,7
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,lastt001,"Tommy La Stella",1,6,5
+start,russa002,"Addison Russell",1,7,6
+start,fedet001,"Tim Federowicz",1,8,2
+start,lackj001,"John Lackey",1,9,1
+play,1,0,markn001,12,CBCX,43/G
+play,1,0,aybae001,00,X,8/F
+play,1,0,freef001,22,BFBFX,7/F
+play,1,1,fowld001,22,CBBFX,S6/G
+play,1,1,heywj001,11,C1BX,13/L+.1-2
+play,1,1,bryak001,12,BFFT,K
+play,1,1,rizza001,31,CB*BBB,W
+play,1,1,zobrb001,02,CF>B,SB3;SB2
+play,1,1,zobrb001,32,CF>B.B*BFC,K
+play,2,0,garca004,22,BCCFBX,43/G
+play,2,0,johnk003,12,CSBX,13/G
+play,2,0,flowt001,22,BBCSFFX,53/G
+play,2,1,lastt001,20,BBX,8/L
+play,2,1,russa002,22,BFBSS,K
+play,2,1,fedet001,11,CBX,7/F
+play,3,0,petej002,02,CSFX,63/G
+play,3,0,tehej001,02,CSFX,9/F
+play,3,0,smitm007,12,CBCX,13/G-
+play,3,1,lackj001,02,CCFFFFC,K
+play,3,1,fowld001,22,CBBFS,K
+play,3,1,heywj001,31,BCBBX,31/G
+play,4,0,markn001,31,BCBBB,W
+play,4,0,aybae001,12,CF*BC,K
+play,4,0,freef001,00,X,9/L
+play,4,0,garca004,00,X,6/P
+play,4,1,bryak001,22,CBSFBFFC,K
+play,4,1,rizza001,10,BX,S9/G
+play,4,1,zobrb001,31,B*BBCX,8/F
+play,4,1,lastt001,10,BX,43/G
+play,5,0,johnk003,11,LBX,D7/L
+play,5,0,flowt001,00,X,43/G.2-3
+play,5,0,petej002,00,X,9/L/SF.3-H
+play,5,0,tehej001,22,FFBBC,K
+play,5,1,russa002,12,FBFX,9/F
+play,5,1,fedet001,32,SSBBBX,8/F
+play,5,1,lackj001,02,CFS,K
+play,6,0,smitm007,00,X,S8/G+
+play,6,0,markn001,31,B*B11CBB,W.1-2
+play,6,0,aybae001,01,MX,14/BG/SH.2-3;1-2
+play,6,0,freef001,30,IIII,IW
+play,6,0,garca004,22,CSBF*BX,E6/FO/G.3-H;2-3;1-2
+play,6,0,johnk003,00,X,43/GDP.3-H(UR);2-3;1X2(36)
+play,6,1,fowld001,32,CCBBBX,8/L
+play,6,1,heywj001,01,CX,43/G
+play,6,1,bryak001,12,BFCS,K
+play,7,0,flowt001,10,BX,53/G
+play,7,0,petej002,00,X,3/L
+play,7,0,tehej001,11,BFX,7/L-
+play,7,1,rizza001,00,,NP
+sub,franj004,"Jeff Francoeur",0,4,7
+play,7,1,rizza001,21,.CBBX,8/F
+play,7,1,zobrb001,00,X,8/F
+play,7,1,lastt001,12,BCSH,HP
+play,7,1,russa002,12,FSFBFS,K
+play,8,0,smitm007,12,BCCX,D7/L/MREV.BX3(765)
+com,"replay,8,smitm007,ATL,culbf901,CHI11,,N,M,ATL,A"
+com,"$when Mallex Smith was called out at 3B, Braves"
+com,"manager Fredi Gonzalez challenged the ruling;"
+com,"the call was upheld by replay"
+play,8,0,markn001,11,BCX,8/L
+play,8,0,aybae001,22,BCFBFFX,31/G
+play,8,1,fedet001,00,,NP
+sub,johnj010,"Jim Johnson",0,8,1
+play,8,1,fedet001,12,.CCBX,7/L
+play,8,1,lackj001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,8,1,szczm001,11,.BCX,S1/BG
+play,8,1,fowld001,10,*BX,D9/L.1-3
+play,8,1,heywj001,00,,NP
+sub,cervh001,"Hunter Cervenka",0,8,1
+play,8,1,heywj001,12,.*BCFX,43/G.3-H;2-3
+play,8,1,bryak001,00,,NP
+sub,vizca001,"Arodys Vizcaino",0,2,1
+play,8,1,bryak001,00,,NP
+sub,castd001,"Daniel Castro",0,8,6
+play,8,1,bryak001,01,..SX,S7/L.3-H
+play,8,1,rizza001,22,CBSBS,K
+play,9,0,freef001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,9,0,freef001,22,.CBSBFX,31/G-
+play,9,0,franj004,30,BBBB,W
+play,9,0,johnk003,01,FX,8/F
+play,9,0,flowt001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,9,0,flowt001,11,.1BSB,WP.1-2
+play,9,0,flowt001,21,.1BSB.X,8/L
+play,9,1,zobrb001,31,BBCBB,W
+play,9,1,lastt001,02,1C>LS,K
+play,9,1,russa002,00,11,PO1(E1).1-3
+play,9,1,russa002,02,11.SCX,S9/G.3-H(UR)
+play,9,1,fedet001,12,BMCX,8/F
+play,9,1,grimj002,00,,NP
+sub,solej001,"Jorge Soler",1,9,11
+play,9,1,solej001,00,.X,63/G
+play,10,0,petej002,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,10,0,petej002,12,.CFBS,K
+play,10,0,castd001,01,CX,S9/G
+play,10,0,smitm007,10,B>X,S7/G.1-3
+play,10,0,markn001,11,1CB>X,7/L/SF.3-H
+play,10,0,vizca001,00,,NP
+sub,stubd001,"Drew Stubbs",0,2,11
+play,10,0,stubd001,01,.C>C,SB2
+play,10,0,stubd001,02,.C>C.S,K
+play,10,1,fowld001,00,,NP
+sub,grilj001,"Jason Grilli",0,2,1
+play,10,1,fowld001,31,.BBBCX,63/G
+play,10,1,heywj001,22,BBCFS,K
+play,10,1,bryak001,32,CBBBCFB,W
+play,10,1,rizza001,10,BX,7/F
+data,er,tehej001,0
+data,er,johnj010,2
+data,er,cervh001,0
+data,er,vizca001,0
+data,er,grilj001,0
+data,er,lackj001,2
+data,er,woodt004,0
+data,er,grimj002,0
+data,er,rondh001,1
+id,CHN201605050
+version,2
+info,visteam,WAS
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/05
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,carav901
+info,ump1b,hirsj901
+info,ump2b,fagac901
+info,ump3b,reybd901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,47
+info,winddir,rtol
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,185
+info,attendance,37564
+info,wp,hendk001
+info,lp,rossj002
+info,save,
+start,taylm002,"Michael Taylor",0,1,8
+start,renda001,"Anthony Rendon",0,2,5
+start,harpb003,"Bryce Harper",0,3,9
+start,zimmr001,"Ryan Zimmerman",0,4,3
+start,murpd006,"Daniel Murphy",0,5,4
+start,wertj001,"Jayson Werth",0,6,7
+start,ramow001,"Wilson Ramos",0,7,2
+start,espid001,"Danny Espinosa",0,8,6
+start,rossj002,"Joe Ross",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,lastt001,"Tommy La Stella",1,2,5
+start,bryak001,"Kris Bryant",1,3,9
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,kalir001,"Ryan Kalish",1,6,7
+start,russa002,"Addison Russell",1,7,6
+start,fedet001,"Tim Federowicz",1,8,2
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,taylm002,11,CBX,63/G
+play,1,0,renda001,12,CCBX,6/P
+play,1,0,harpb003,32,BSBBF*B,W
+play,1,0,zimmr001,22,1C*B1BC>FX,64(1)/FO/G
+play,1,1,fowld001,22,BCSBC,K
+play,1,1,lastt001,01,CX,D7/L
+play,1,1,bryak001,31,BSBBX,43/G.2-3
+play,1,1,rizza001,02,FSX,9/F
+play,2,0,murpd006,22,CCFFBFBX,8/F
+play,2,0,wertj001,22,CBFBFS,K
+play,2,0,ramow001,00,X,9/F
+play,2,1,zobrb001,11,BFX,5/L
+play,2,1,kalir001,12,BFCFX,43/G
+play,2,1,russa002,12,CFBS,K23
+play,3,0,espid001,00,X,5/BL-
+play,3,0,rossj002,11,CBX,13/G-
+play,3,0,taylm002,00,X,D7/L
+play,3,0,renda001,01,CX,13/G
+play,3,1,fedet001,22,CCBBC,K
+play,3,1,hendk001,12,CBFS,K
+play,3,1,fowld001,02,SCC,K
+com,"ej,fowld001,P,carav901,Balls and strikes"
+com,"Cubs center fielder Dexter Fowler ejected by HP umpire Vic Carapazza"
+play,4,0,harpb003,00,,NP
+sub,heywj001,"Jason Heyward",1,1,8
+play,4,0,harpb003,32,..BBCSBFB,W
+play,4,0,zimmr001,11,1BC1,PO1(13)
+play,4,0,zimmr001,11,1BC1.X,43/G
+play,4,0,murpd006,22,CBBFC,K
+play,4,1,lastt001,01,CX,S8/G
+play,4,1,bryak001,00,X,DGR/8/F.1-3
+com,"$the ball went into the vines"
+play,4,1,rizza001,30,BBBI,IW
+play,4,1,zobrb001,10,BX,S9/G/MREV.3-H;2-H;1X3(95)
+com,"replay,4,zobrb001,CHN,hirsj901,CHI11,,N,M,CHN,A"
+com,"$when Anthony Rizzo was called out at 3B, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was upheld by replay"
+play,4,1,kalir001,10,11BX,43/G.1-2
+play,4,1,russa002,32,SBSBBFS,K
+play,5,0,wertj001,32,CBBBFX,43/G
+play,5,0,ramow001,11,CBX,63/G-
+play,5,0,espid001,22,BFSBFH,HP
+play,5,0,rossj002,00,X,63/G
+play,5,1,fedet001,21,BBCX,8/F
+play,5,1,hendk001,01,FH,HP
+play,5,1,heywj001,22,CCBFBC,K
+play,5,1,lastt001,10,BX,9/L
+play,6,0,taylm002,01,FX,53/G
+play,6,0,renda001,22,CBBFC,K
+play,6,0,harpb003,22,BCFBX,S9/L
+play,6,0,zimmr001,02,FCS,K
+play,6,1,bryak001,31,CBBBX,43/G
+play,6,1,rizza001,12,BFCFS,K
+play,6,1,zobrb001,22,CBBCFX,3/L
+play,7,0,murpd006,00,,NP
+sub,richc002,"Clayton Richard",1,9,1
+play,7,0,murpd006,02,.CFFS,K
+play,7,0,wertj001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,7,0,wertj001,12,.CBSX,63/G
+play,7,0,ramow001,00,X,63/G
+play,7,1,kalir001,00,X,S8/L
+play,7,1,russa002,12,1L1C*BS,K
+play,7,1,fedet001,32,B1BBCS>FX,8/F
+play,7,1,grimj002,00,,NP
+sub,solej001,"Jorge Soler",1,9,11
+play,7,1,solej001,30,.*B*BBB,W.1-2
+play,7,1,heywj001,00,,NP
+sub,solis001,"Sammy Solis",0,9,1
+play,7,1,heywj001,02,.FSFX,6/P
+play,8,0,espid001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,8,0,espid001,22,.BCSBH,HP
+play,8,0,solis001,00,,NP
+sub,robic001,"Clint Robinson",0,9,11
+play,8,0,robic001,32,.BBBCFB,W.1-2
+play,8,0,taylm002,22,S*BBFS,K
+play,8,0,renda001,01,CX,46(1)3/GDP
+play,8,1,lastt001,00,,NP
+sub,rivef001,"Felipe Rivero",0,9,1
+play,8,1,lastt001,02,.CCFFX,S3/G+
+play,8,1,bryak001,12,BFSS,K
+play,8,1,rizza001,01,CX,7/F
+play,8,1,zobrb001,12,11CBC1,OA/MREV
+com,"replay,8,zobrb001,CHN,hirsj901,CHI11,,N,M,WAS,A"
+com,"$when Tommy La Stella was called safe at 1B on a"
+com,"pickoff attempt, Nationals manager Dusty Baker"
+com,"challenged the ruling; the call was upheld"
+com,"by replay"
+play,8,1,zobrb001,12,11CBC1>FX,HR/78/F.1-H
+play,8,1,kalir001,12,CSBFH,HP
+play,8,1,russa002,00,,NP
+sub,kells001,"Shawn Kelley",0,9,1
+play,8,1,russa002,22,.CBBFX,D7/L.1-H
+play,8,1,fedet001,12,SBFC,K
+play,9,0,harpb003,00,,NP
+sub,woodt004,"Travis Wood",1,2,1
+play,9,0,harpb003,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,9,0,harpb003,32,..BBFCBB,W
+play,9,0,zimmr001,12,CC*BFX,8/L
+play,9,0,murpd006,01,CX,8/F
+play,9,0,wertj001,00,>C,DI.1-2
+play,9,0,wertj001,22,>C.BCFBFFX,HR/7/F.2-H
+play,9,0,ramow001,00,,NP
+sub,rondh001,"Hector Rondon",1,2,1
+play,9,0,ramow001,12,.FFBX,3/L
+data,er,rossj002,2
+data,er,solis001,0
+data,er,rivef001,3
+data,er,kells001,0
+data,er,hendk001,0
+data,er,richc002,0
+data,er,grimj002,0
+data,er,strop001,0
+data,er,woodt004,2
+data,er,rondh001,0
+id,CHN201605060
+version,2
+info,visteam,WAS
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/06
+info,number,0
+info,starttime,1:22PM
+info,daynight,day
+info,usedh,false
+info,umphome,hirsj901
+info,ump1b,fagac901
+info,ump2b,reybd901
+info,ump3b,carav901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,73
+info,winddir,tocf
+info,windspeed,9
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,166
+info,attendance,39206
+info,wp,lackj001
+info,lp,schem001
+info,save,rondh001
+start,reveb001,"Ben Revere",0,1,8
+start,renda001,"Anthony Rendon",0,2,5
+start,harpb003,"Bryce Harper",0,3,9
+start,zimmr001,"Ryan Zimmerman",0,4,3
+start,murpd006,"Daniel Murphy",0,5,4
+start,wertj001,"Jayson Werth",0,6,7
+start,ramow001,"Wilson Ramos",0,7,2
+start,espid001,"Danny Espinosa",0,8,6
+start,schem001,"Max Scherzer",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,7
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,lastt001,"Tommy La Stella",1,6,5
+start,baezj001,"Javier Baez",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,lackj001,"John Lackey",1,9,1
+play,1,0,reveb001,12,BCCS,K
+play,1,0,renda001,32,BCBBFFX,HR/78/F
+play,1,0,harpb003,00,X,43/G
+play,1,0,zimmr001,12,FCBS,K
+play,1,1,fowld001,22,CBFBFFS,K
+play,1,1,heywj001,32,CSBBBB,W
+play,1,1,bryak001,22,BFS1BS,K
+play,1,1,rizza001,00,B,PB.1-2
+play,1,1,rizza001,32,B.CBBFX,43/G
+play,2,0,murpd006,00,X,D9/F
+play,2,0,wertj001,02,FCS,K
+play,2,0,ramow001,12,CSBX,S6/G.2-3
+play,2,0,espid001,32,BLF*B*BC,K
+play,2,0,schem001,01,SX,S9/G.3-H;1-2
+play,2,0,reveb001,00,X,8/L
+play,2,1,zobrb001,32,BCBFBB,W
+play,2,1,lastt001,00,X,HR/89/F.1-H
+play,2,1,baezj001,02,CSS,K
+play,2,1,rossd001,01,CX,53/G
+play,2,1,lackj001,22,BBCSX,S8/L
+play,2,1,fowld001,01,SX,6/P
+play,3,0,renda001,11,CBX,8/F
+play,3,0,harpb003,12,FBFFS,K
+play,3,0,zimmr001,32,BBBCCX,8/F
+play,3,1,heywj001,31,BFBBX,6/P
+play,3,1,bryak001,12,CFBS,K
+play,3,1,rizza001,01,CX,HR/9/F/UREV
+com,"replay,3,rizza001,CHN,hirsj901,CHI11,F,N,U,,H"
+com,"$Anthony Rizzo's fly to RF curled around the pole;"
+com,"crew chief John Hirschbeck requested a review, which"
+com,"upheld the call of home run"
+play,3,1,zobrb001,11,BCX,HR/9/F
+play,3,1,lastt001,00,X,5/P
+play,4,0,murpd006,32,BCBBFX,S4/G
+play,4,0,wertj001,22,CCB*BFFC,K
+play,4,0,ramow001,31,BBCBX,9/L
+play,4,0,espid001,21,1BBCH,HP.1-2
+play,4,0,schem001,02,CSS,K
+play,4,1,baezj001,12,CBSFFS,K
+play,4,1,rossd001,21,BSBX,31/G-
+play,4,1,lackj001,00,X,63/G
+play,5,0,reveb001,01,CX,3/G
+play,5,0,renda001,32,BFSBBB,W
+play,5,0,harpb003,12,FCBS,K+PO1(23)/DP
+play,5,1,fowld001,02,CCX,7/F
+play,5,1,heywj001,20,BBX,D8/L
+play,5,1,bryak001,32,SBSF*BFBC,K
+play,5,1,rizza001,30,BBBB,W
+play,5,1,zobrb001,00,X,HR/9/L.2-H;1-H
+play,5,1,lastt001,12,BFFX,T9/L
+play,5,1,baezj001,02,CFFS,K
+play,6,0,zimmr001,22,CBFBFX,63/G
+play,6,0,murpd006,01,CX,S9/G+
+play,6,0,wertj001,12,SC*BFS,K
+play,6,0,ramow001,00,X,6/P
+play,6,1,rossd001,00,,NP
+sub,treib001,"Blake Treinen",0,9,1
+play,6,1,rossd001,00,.X,D9/L
+play,6,1,lackj001,10,BX,14/BG/SH.2-3
+play,6,1,fowld001,11,BSX,S8/G.3-H
+play,6,1,heywj001,00,X,46(1)3/GDP
+play,7,0,espid001,02,CSS,K
+play,7,0,treib001,00,,NP
+sub,drews001,"Stephen Drew",0,9,11
+play,7,0,drews001,22,.CSFBBFS,K
+play,7,0,reveb001,11,CBX,13/G
+play,7,1,bryak001,00,,NP
+sub,pereo002,"Oliver Perez",0,9,1
+play,7,1,bryak001,10,.BX,43/G+
+play,7,1,rizza001,31,BCBBB,W
+play,7,1,zobrb001,00,B,WP.1-2
+play,7,1,zobrb001,31,B.BBCB,W+PB.2-3
+play,7,1,lastt001,00,X,64(1)3/GDP
+play,8,0,renda001,00,,NP
+sub,richc002,"Clayton Richard",1,9,1
+play,8,0,renda001,01,.CX,43/G
+play,8,0,harpb003,31,BBBCB,W
+play,8,0,zimmr001,02,CFFS,K
+play,8,0,murpd006,11,F*BX,S67/G.1-2
+play,8,0,wertj001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,8,0,wertj001,21,.CBBX,D7/L+.2-H;1-H
+play,8,0,ramow001,00,X,HR/78/L+.2-H
+play,8,0,espid001,02,CSC,K
+play,8,1,baezj001,00,,NP
+sub,kells001,"Shawn Kelley",0,9,1
+play,8,1,baezj001,22,.CBFBX,4/L+
+play,8,1,rossd001,01,CX,4/P
+play,8,1,grimj002,00,,NP
+sub,solej001,"Jorge Soler",1,9,11
+play,8,1,solej001,22,.BSBSC,K
+play,9,0,kells001,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,9,0,kells001,00,,NP
+sub,heisc001,"Chris Heisey",0,9,11
+play,9,0,heisc001,22,..FCBBC,K
+play,9,0,reveb001,10,BX,43/G
+play,9,0,renda001,02,CFS,K23
+data,er,schem001,7
+data,er,treib001,1
+data,er,pereo002,0
+data,er,kells001,0
+data,er,lackj001,2
+data,er,richc002,2
+data,er,grimj002,2
+data,er,rondh001,0
+id,CHN201605070
+version,2
+info,visteam,WAS
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/07
+info,number,0
+info,starttime,3:05PM
+info,daynight,day
+info,usedh,false
+info,umphome,fagac901
+info,ump1b,reybd901
+info,ump2b,carav901
+info,ump3b,hirsj901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,speaa701
+info,temp,51
+info,winddir,fromlf
+info,windspeed,23
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,212
+info,attendance,40471
+info,wp,warra001
+info,lp,solis001
+info,save,rondh001
+start,reveb001,"Ben Revere",0,1,8
+start,espid001,"Danny Espinosa",0,2,6
+start,harpb003,"Bryce Harper",0,3,9
+start,zimmr001,"Ryan Zimmerman",0,4,3
+start,wertj001,"Jayson Werth",0,5,7
+start,renda001,"Anthony Rendon",0,6,5
+start,drews001,"Stephen Drew",0,7,4
+start,lobaj001,"Jose Lobaton",0,8,2
+start,gonzg003,"Gio Gonzalez",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,solej001,"Jorge Soler",1,6,7
+start,russa002,"Addison Russell",1,7,6
+start,fedet001,"Tim Federowicz",1,8,2
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,reveb001,22,BCCBX,43/G
+play,1,0,espid001,32,BFFBBFX,8/F
+play,1,0,harpb003,31,BCBBB,W
+play,1,0,zimmr001,12,111CBFB,WP.1-2
+play,1,0,zimmr001,32,111CBFB.BFX,63/G
+play,1,1,fowld001,01,FX,7/L
+play,1,1,heywj001,32,CCFBBFBFS,K
+play,1,1,bryak001,22,BFBSX,8/F
+play,2,0,wertj001,02,CCS,K
+play,2,0,renda001,20,BBX,8/F
+play,2,0,drews001,12,CBLFX,S4/G-
+play,2,0,lobaj001,32,BF1FF*B*B>B,W.1-2
+play,2,0,gonzg003,02,FSS,K
+play,2,1,rizza001,32,BCBBCX,5/P
+play,2,1,zobrb001,21,CBBX,63/G
+play,2,1,solej001,00,X,63/G
+play,3,0,reveb001,01,CX,D9/L
+play,3,0,espid001,11,LBX,34/BG/SH.2-3
+play,3,0,harpb003,02,SFX,9/F/SF.3-H
+play,3,0,zimmr001,10,BX,4/P
+play,3,1,russa002,01,CX,31/G
+play,3,1,fedet001,32,CBSBFBFFX,S7/L
+play,3,1,hammj002,11,LB1X,14/BG/SH.1-2
+play,3,1,fowld001,22,BSFBFX,T8/F.2-H
+play,3,1,heywj001,12,CBFX,3/G
+play,4,0,wertj001,02,CFX,31/G-
+play,4,0,renda001,22,BBCSX,43/G
+play,4,0,drews001,22,BCSBS,K
+play,4,1,bryak001,02,CSX,HR/7/F
+play,4,1,rizza001,22,BBCCFX,53/G
+play,4,1,zobrb001,21,FBBX,9/F
+play,4,1,solej001,11,FBX,8/F
+play,5,0,lobaj001,31,CBBBB,W
+play,5,0,gonzg003,12,LS*BX,14/BG/SH.1-2
+play,5,0,reveb001,32,BB*BCFX,43/G.2-3
+play,5,0,espid001,21,*BBSX,S49/G.3-H
+play,5,0,harpb003,31,1BBBCB,W.1-2
+play,5,0,zimmr001,10,BX,S8/G.2-H;1-3
+play,5,0,wertj001,01,CF,FLE3
+play,5,0,wertj001,02,CFX,7/F
+play,5,1,russa002,32,BCTFBFFBB,W
+play,5,1,fedet001,02,1CF1C,K
+play,5,1,hammj002,00,X,24/BG/SH.1-2
+play,5,1,fowld001,12,BCFX,S6/G-.2-3
+play,5,1,heywj001,22,CBBFX,43/G
+play,6,0,renda001,00,,NP
+sub,patts002,"Spencer Patton",1,9,1
+play,6,0,renda001,31,.BFBBB,W
+play,6,0,drews001,10,1B>S,SB2
+play,6,0,drews001,11,1B>S.X,D8/L.2-H
+play,6,0,lobaj001,00,,NP
+sub,richc002,"Clayton Richard",1,9,1
+play,6,0,lobaj001,10,.BX,3/G.2-3
+play,6,0,gonzg003,20,BBX,FC2/BG/DP.3XH(2525);BX2(54)
+play,6,1,bryak001,00,X,8/L
+play,6,1,rizza001,00,X,S9/G+
+play,6,1,zobrb001,11,CBX,13/BG/SH.1-2
+play,6,1,solej001,11,CBX,S9/L.2-3
+play,6,1,russa002,11,FBX,S8/G.3-H;1-2
+play,6,1,fedet001,00,,NP
+sub,treib001,"Blake Treinen",0,9,1
+play,6,1,fedet001,00,,NP
+sub,lastt001,"Tommy La Stella",1,8,11
+play,6,1,lastt001,30,..B*BBB,W.2-3;1-2
+play,6,1,richc002,00,,NP
+sub,kalir001,"Ryan Kalish",1,9,11
+play,6,1,kalir001,00,,NP
+sub,solis001,"Sammy Solis",0,9,1
+play,6,1,kalir001,22,..BCBFFX,S7/L-.3-H;2-H;1-2
+play,6,1,fowld001,21,BFBX,8/F
+play,7,0,reveb001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,7,0,reveb001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,7,0,reveb001,00,,NP
+sub,lastt001,"Tommy La Stella",1,8,5
+play,7,0,reveb001,00,,NP
+sub,rossd001,"David Ross",1,6,2
+play,7,0,reveb001,21,....CBBX,T9/L
+play,7,0,espid001,00,,NP
+sub,warra001,"Adam Warren",1,9,1
+play,7,0,espid001,12,.BFSFS,K
+play,7,0,harpb003,30,IIII,IW
+play,7,0,zimmr001,22,CBSFBX,54(1)/FO/G/MREV.3-H
+com,"replay,7,zimmr001,WAS,hirsj901,CHI11,,N,M,CHN,C"
+com,"$when Ryan Zimmerman was called safe at 1B, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was upheld by replay"
+play,7,0,wertj001,11,CBX,8/L
+play,7,1,heywj001,12,CFFBFFT,K
+play,7,1,bryak001,30,BBBB,W
+play,7,1,rizza001,22,11CBFBX,DGR/7/L.1-3
+play,7,1,zobrb001,30,IIII,IW
+play,7,1,rossd001,00,,NP
+sub,kells001,"Shawn Kelley",0,9,1
+play,7,1,rossd001,12,.CCFF*BX,4/L-
+play,7,1,russa002,22,SBBCX,D9/F/MREV.3-H;2-H;1-3
+com,"replay,7,russa002,CHN,hirsj901,CHI11,,N,M,WAS,O"
+com,"$Addison Russell's fly down the RF line was touched"
+com,"by Bryce Harper at the line and ruled a fair ball;"
+com,"Nationals manager Dusty Baker challenged the ruling,"
+com,"which was upheld by replay"
+play,7,1,lastt001,30,IIII,IW
+play,7,1,warra001,00,,NP
+sub,baezj001,"Javier Baez",1,9,11
+play,7,1,baezj001,00,.X,5(2)/FO/G.1-2
+play,8,0,renda001,00,,NP
+sub,strop001,"Pedro Strop",1,8,1
+play,8,0,renda001,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,8,0,renda001,12,..BCCS,K
+play,8,0,drews001,22,BSBFS,K
+play,8,0,lobaj001,00,,NP
+sub,ramow001,"Wilson Ramos",0,8,11
+play,8,0,ramow001,12,.SCBS,K
+play,8,1,fowld001,00,,NP
+sub,rivef001,"Felipe Rivero",0,7,1
+play,8,1,fowld001,00,,NP
+sub,ramow001,"Wilson Ramos",0,8,2
+play,8,1,fowld001,00,,NP
+sub,murpd006,"Daniel Murphy",0,9,4
+play,8,1,fowld001,31,...BBBCB,W
+play,8,1,heywj001,31,1BBBCB,W.1-2
+play,8,1,bryak001,02,CSS,K
+play,8,1,rizza001,21,BCBH,HP.2-3;1-2
+play,8,1,zobrb001,21,S*BBX,S9/L.3-H;2-3;1-2
+play,8,1,rossd001,02,SSS,K
+play,8,1,russa002,12,SSBS,K
+play,9,0,murpd006,00,,NP
+sub,rondh001,"Hector Rondon",1,8,1
+play,9,0,murpd006,10,.BX,7/F
+play,9,0,reveb001,12,CCBFC,K
+play,9,0,espid001,00,X,53/G
+data,er,gonzg003,5
+data,er,treib001,0
+data,er,solis001,2
+data,er,kells001,0
+data,er,rivef001,1
+data,er,hammj002,3
+data,er,patts002,1
+data,er,richc002,0
+data,er,woodt004,1
+data,er,warra001,0
+data,er,strop001,0
+data,er,rondh001,0
+id,CHN201605080
+version,2
+info,visteam,WAS
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/08
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,reybd901
+info,ump1b,carav901
+info,ump2b,hirsj901
+info,ump3b,fagac901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,61
+info,winddir,rtol
+info,windspeed,7
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,294
+info,attendance,41233
+info,wp,woodt004
+info,lp,treib001
+info,save,
+start,reveb001,"Ben Revere",0,1,8
+start,renda001,"Anthony Rendon",0,2,5
+start,harpb003,"Bryce Harper",0,3,9
+start,zimmr001,"Ryan Zimmerman",0,4,3
+start,murpd006,"Daniel Murphy",0,5,4
+start,wertj001,"Jayson Werth",0,6,7
+start,ramow001,"Wilson Ramos",0,7,2
+start,espid001,"Danny Espinosa",0,8,6
+start,roart001,"Tanner Roark",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,solej001,"Jorge Soler",1,6,7
+start,russa002,"Addison Russell",1,7,6
+start,fedet001,"Tim Federowicz",1,8,2
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,reveb001,22,BCFBS,K
+play,1,0,renda001,00,X,S9/L
+play,1,0,harpb003,30,B1BBB,W.1-2
+play,1,0,zimmr001,02,CFC,K
+play,1,0,murpd006,32,BBFBF>F>X,9/F
+play,1,1,fowld001,12,CBCH,HP
+play,1,1,heywj001,12,F1FF*BX,64(1)/FO/G
+play,1,1,bryak001,20,BBX,S7/L.1-2
+play,1,1,rizza001,10,*B2X,5/P5F
+play,1,1,zobrb001,32,CCB*BB>B,W.2-3;1-2
+play,1,1,solej001,12,CBCC,K
+play,2,0,wertj001,22,BBCSX,53/G
+play,2,0,ramow001,32,CSBBFBFFB,W
+play,2,0,espid001,12,C*BCS,K
+play,2,0,roart001,12,BSFB,WP.1-2
+play,2,0,roart001,22,BSFB.S,K+WP.2-3;B-1
+play,2,0,reveb001,00,X,146(1)/FO/G
+play,2,1,russa002,22,FCBBS,K23
+play,2,1,fedet001,10,BX,9/F9LF
+play,2,1,arrij001,22,BBCCC,K
+play,3,0,renda001,12,CCBS,K23
+play,3,0,harpb003,31,CBBBB,W
+play,3,0,zimmr001,01,C>X,D5/G+.1-H
+play,3,0,murpd006,32,BBBCFFX,43/G.2-3
+play,3,0,wertj001,01,FX,23/G-
+play,3,1,fowld001,20,BBX,D9/L
+play,3,1,heywj001,01,FX,63/G
+play,3,1,bryak001,22,BSF*BX,53/G
+play,3,1,rizza001,21,BCB>C,SB3
+play,3,1,rizza001,22,BCB>C.T,K
+play,4,0,ramow001,00,X,S7/L
+play,4,0,espid001,00,X,S8/G+.1-2
+play,4,0,roart001,00,B,WP.2-3
+play,4,0,roart001,10,B.X,E1/G-.1-2
+play,4,0,reveb001,21,BC*BX,7/L
+play,4,0,renda001,01,FX,43/G.3-H(UR);2-3;1-2
+play,4,0,harpb003,30,IIII,IW
+play,4,0,zimmr001,12,CFF*BS,K
+play,4,1,zobrb001,12,CFBX,E4/G
+play,4,1,solej001,30,B1*B+1BX,53/G+.1-2
+play,4,1,russa002,02,FCX,43/G-.2-3
+play,4,1,fedet001,02,CSB,WP.3-H(UR)(NR)
+play,4,1,fedet001,22,CSB.BS,K
+play,5,0,murpd006,12,BCFFX,D7/L
+play,5,0,wertj001,02,CFX,8/F.2-3
+play,5,0,ramow001,11,SBX,S7/L.3-H
+play,5,0,espid001,02,CFS,K
+play,5,0,roart001,02,CCX,13/G
+play,5,1,arrij001,00,,NP
+sub,kalir001,"Ryan Kalish",1,9,11
+play,5,1,kalir001,32,.BBCFFBFB,W
+play,5,1,fowld001,32,FBCB+1FBX,5/P
+play,5,1,heywj001,00,B,WP.1-2
+play,5,1,heywj001,32,B.BSC*BX,3/G.2-3
+play,5,1,bryak001,12,CCFBS,K
+play,6,0,reveb001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,6,0,reveb001,31,.BBSBB,W
+play,6,0,renda001,00,X,53/G.1-2
+play,6,0,harpb003,00,H,HP
+play,6,0,zimmr001,22,CFB*BX,9/L
+play,6,0,murpd006,20,BBX,7/F
+play,6,1,rizza001,00,X,S1/BG
+play,6,1,zobrb001,21,BBFX,53/G-.1-2
+play,6,1,solej001,12,FBCS,K
+play,6,1,russa002,02,CCX,S1/G.2-3
+play,6,1,fedet001,00,,NP
+sub,lastt001,"Tommy La Stella",1,8,11
+play,6,1,lastt001,31,.BB1F*BX,9/L
+play,7,0,wertj001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,7,0,wertj001,00,,NP
+sub,rossd001,"David Ross",1,6,2
+play,7,0,wertj001,00,,NP
+sub,lastt001,"Tommy La Stella",1,8,5
+play,7,0,wertj001,02,...CCS,K
+play,7,0,ramow001,32,CBCBBFX,13/G
+play,7,0,espid001,31,BBCBX,D9/L
+play,7,0,roart001,00,,NP
+sub,drews001,"Stephen Drew",0,9,11
+play,7,0,drews001,22,.BBSCFFS,K
+play,7,1,cahit001,00,,NP
+sub,pereo002,"Oliver Perez",0,9,1
+play,7,1,cahit001,02,.CCFX,S16/L+
+play,7,1,fowld001,30,BBBH,HP.1-2
+play,7,1,heywj001,00,X,54/BG/SH.2-3;1-2
+play,7,1,bryak001,00,,NP
+sub,petiy001,"Yusmeiro Petit",0,9,1
+play,7,1,bryak001,10,.BX,S8/G.3-H;2-H
+play,7,1,rizza001,00,X,9/F
+play,7,1,zobrb001,12,CC1B1*B,SB2/MREV
+com,"replay,7,zobrb001,CHN,hirsj901,CHI11,,N,M,WAS,A"
+com,"$when Kris Bryant was called safe at 2B, Nationals"
+com,"manager Dusty Baker challenged the ruling; the"
+com,"call was upheld by replay"
+play,7,1,zobrb001,22,CC1B1*B.X,43/G
+play,8,0,reveb001,21,BBCX,43/G
+play,8,0,renda001,22,CCBBX,7/F
+play,8,0,harpb003,31,BBCBB,W
+play,8,0,zimmr001,21,1S1BBX,3/G
+play,8,1,rossd001,02,FCFX,53/G
+play,8,1,russa002,00,X,3/P3F
+play,8,1,lastt001,12,BFSX,S7/L-
+play,8,1,cahit001,00,,NP
+sub,baezj001,"Javier Baez",1,9,11
+play,8,1,baezj001,22,.1BBCS1X,7/L
+play,9,0,murpd006,00,,NP
+sub,warra001,"Adam Warren",1,8,1
+play,9,0,murpd006,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,9,0,murpd006,00,..X,S8/L
+play,9,0,wertj001,12,SSBX,64(1)3/GDP
+play,9,0,ramow001,00,X,13/G-
+play,9,1,fowld001,32,BBCBFS,K
+play,9,1,heywj001,11,CBX,S9/L+
+play,9,1,bryak001,12,F1BCX,8/L
+play,9,1,rizza001,10,BX,S/G/BR.1X2(4)
+play,10,0,espid001,32,BBBCSX,S9/G
+play,10,0,petiy001,11,BLX,34/BG/SH.1-2
+play,10,0,reveb001,31,BCBBB,W
+play,10,0,renda001,12,CCBX,7/F
+play,10,0,harpb003,30,IIII,IW.2-3;1-2
+play,10,0,zimmr001,01,CX,7/L
+play,10,1,zobrb001,12,CFBX,S9/G
+play,10,1,rossd001,00,1X,8/L
+play,10,1,russa002,10,1BX,S7/G.1-2
+play,10,1,warra001,00,,NP
+sub,hammj002,"Jason Hammel",1,8,11
+play,10,1,hammj002,12,.BFFC,K
+play,10,1,baezj001,32,BBSFFFB>X,9/F
+play,11,0,murpd006,00,,NP
+sub,grimj002,"Justin Grimm",1,8,1
+play,11,0,murpd006,30,.BBBX,9/F
+play,11,0,wertj001,02,FTX,9/F
+play,11,0,ramow001,11,BCX,63/G
+play,11,1,fowld001,00,,NP
+sub,reveb001,"Ben Revere",0,1,7
+play,11,1,fowld001,00,,NP
+sub,papej001,"Jonathan Papelbon",0,6,1
+play,11,1,fowld001,00,,NP
+sub,taylm002,"Michael Taylor",0,9,8
+play,11,1,fowld001,11,...FBX,8/L
+play,11,1,heywj001,00,X,S6/G
+play,11,1,bryak001,02,1CF1X,D8/F/MREV.1XH(862)
+com,"replay,11,bryak001,CHN,hirsj901,CHI11,,N,M,CHN,P"
+com,"$when Jason Heyward was called out at HP, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was upheld by replay"
+play,11,1,rizza001,22,CFF*BFBX,2/P
+play,12,0,espid001,00,X,8/F
+play,12,0,taylm002,21,BBSX,63/G
+play,12,0,reveb001,02,CSX,S8/G
+play,12,0,renda001,30,*BB1B1B,W.1-2
+play,12,0,harpb003,30,IIII,IW.2-3;1-2
+play,12,0,zimmr001,12,BCCFX,53/G-
+play,12,1,zobrb001,32,BFSBBFB,W
+play,12,1,rossd001,32,P1BCSB>F>F>X,9/L
+play,12,1,russa002,10,1BX,46(1)3/GDP
+play,13,0,murpd006,00,,NP
+sub,woodt004,"Travis Wood",1,8,1
+play,13,0,murpd006,20,.BBX,63/G
+play,13,0,papej001,00,,NP
+sub,heisc001,"Chris Heisey",0,6,11
+play,13,0,heisc001,01,.FX,2/P2F
+play,13,0,ramow001,10,BX,S7/G
+play,13,0,espid001,12,BCCFH,HP.1-2
+play,13,0,taylm002,00,,NP
+sub,rossj002,"Joe Ross",0,7,12
+play,13,0,taylm002,22,.CCBB+2X,8/L
+play,13,1,woodt004,00,,NP
+sub,lobaj001,"Jose Lobaton",0,6,2
+play,13,1,woodt004,00,,NP
+sub,treib001,"Blake Treinen",0,7,1
+play,13,1,woodt004,12,..CBCS,K
+play,13,1,baezj001,22,BCBSX,HR/78/L
+data,er,roart001,0
+data,er,pereo002,2
+data,er,petiy001,0
+data,er,papej001,0
+data,er,treib001,1
+data,er,arrij001,2
+data,er,cahit001,0
+data,er,warra001,0
+data,er,grimj002,0
+data,er,woodt004,0
+id,CHN201605100
+version,2
+info,visteam,SDN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/10
+info,number,0
+info,starttime,7:07PM
+info,daynight,night
+info,usedh,false
+info,umphome,fleta901
+info,ump1b,basnt901
+info,ump2b,westj901
+info,ump3b,danlk901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,54
+info,winddir,fromrf
+info,windspeed,2
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,193
+info,attendance,34680
+info,wp,lestj001
+info,lp,vargc002
+info,save,rondh001
+start,jay-j001,"Jon Jay",0,1,8
+start,myerw001,"Wil Myers",0,2,3
+start,kempm001,"Matt Kemp",0,3,9
+start,norrd001,"Derek Norris",0,4,2
+start,uptob001,"Melvin Upton",0,5,7
+start,wallb001,"Brett Wallace",0,6,5
+start,pirej001,"Jose Pirela",0,7,4
+start,ramia003,"Alexei Ramirez",0,8,6
+start,vargc002,"Cesar Vargas",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,7
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,baezj001,"Javier Baez",1,6,5
+start,russa002,"Addison Russell",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,jay-j001,22,BFCBFX,43/G
+play,1,0,myerw001,32,FFFFBBBFX,8/F
+play,1,0,kempm001,32,CBCBFFFBX,8/L
+play,1,1,fowld001,32,BBCBFS,K
+play,1,1,heywj001,32,FSBBBX,8/L
+play,1,1,bryak001,32,CBFBBX,9/L
+play,2,0,norrd001,11,CBX,8/F
+play,2,0,uptob001,12,CBSX,9/F
+play,2,0,wallb001,01,CX,7/F
+play,2,1,rizza001,11,BCX,3/G
+play,2,1,zobrb001,31,BCBBX,S9/L
+play,2,1,baezj001,00,X,S1/BG.1-2
+play,2,1,russa002,11,FBX,D9/F.2-H;1-3;BX3(9426/TH)
+play,2,1,rossd001,31,BBCBB,W
+play,2,1,lestj001,21,BFBX,46(1)/FO/G
+play,3,0,pirej001,22,BCBCFX,3/P
+play,3,0,ramia003,32,BBFFBFB,W
+play,3,0,vargc002,12,CLBB,WP.1-2
+play,3,0,vargc002,22,CLBB.C,K
+play,3,0,jay-j001,12,BFFH,HP
+play,3,0,myerw001,22,B+2BFSC,K
+play,3,1,fowld001,10,BX,S8/L
+play,3,1,heywj001,11,1BC11X,S7/G.1-2
+play,3,1,bryak001,21,S*BBX,D7/L.2-H;1-H
+play,3,1,rizza001,12,SF*BX,163/G.2-3
+play,3,1,zobrb001,12,BCCX,S9/G.3-H
+play,3,1,baezj001,01,CX,D7/L.1-3
+play,3,1,russa002,30,IIII,IW
+play,3,1,rossd001,31,BBBCX,9/F+/SF.3-H;2-3
+play,3,1,lestj001,00,X,7/F
+play,4,0,kempm001,11,CBX,53/G
+play,4,0,norrd001,22,CBBFX,9/F
+play,4,0,uptob001,12,BCFX,HR/7/F
+play,4,0,wallb001,10,BX,43/G
+play,4,1,fowld001,31,BFBBB,W
+play,4,1,heywj001,11,BSX,46(1)/FO/G
+play,4,1,bryak001,21,F1BBX,53/G.1-2
+play,4,1,rizza001,32,C*BBBFX,S7/L.2-3
+play,4,1,zobrb001,21,CBBX,S9/L.3-H;1-3
+play,4,1,baezj001,10,BX,9/F
+play,5,0,pirej001,00,X,S6/G
+play,5,0,ramia003,11,CBX,D8/L.1-H
+play,5,0,vargc002,00,,NP
+sub,blasj001,"Jabari Blash",0,9,11
+play,5,0,blasj001,00,,NP
+sub,rosaa001,"Adam Rosales",0,8,12
+com,"Padres shortstop Alexei Ramirez left the game due to an injured leg"
+play,5,0,blasj001,01,.S.X,5/P
+play,5,0,jay-j001,22,CFBBX,D9/F.2-H
+play,5,0,myerw001,21,BCBX,7/F
+play,5,0,kempm001,12,FBCC,K
+play,5,1,russa002,00,,NP
+sub,rosaa001,"Adam Rosales",0,8,6
+play,5,1,russa002,00,,NP
+sub,perdl002,"Luis Perdomo",0,9,1
+play,5,1,russa002,32,..FBSBBT,K
+play,5,1,rossd001,22,BBCFX,13/G
+play,5,1,lestj001,11,BFX,63/G+
+play,6,0,norrd001,12,BFCX,63/G
+play,6,0,uptob001,32,CBCBBC,K
+play,6,0,wallb001,10,BX,43/G
+play,6,1,fowld001,31,CBBBB,W
+play,6,1,heywj001,21,BC11BX,6(1)3/GDP
+play,6,1,bryak001,12,FBCS,K
+play,7,0,pirej001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,7,0,pirej001,22,.BCBFC,K
+play,7,0,rosaa001,32,BCFBBB,W
+play,7,0,perdl002,02,FMC,K
+play,7,0,jay-j001,00,,NP
+sub,richc002,"Clayton Richard",1,9,1
+play,7,0,jay-j001,00,..X,S7/G.1-2
+play,7,0,myerw001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,7,0,myerw001,00,.X,E5/G.2-3;1-2
+play,7,0,kempm001,01,CX,9/F
+play,7,1,rizza001,31,BFBBB,W
+play,7,1,zobrb001,01,CX,S9/L.1-2
+play,7,1,baezj001,21,CBBX,3/G.2-3;1-2
+play,7,1,russa002,10,BX,T9/L.3-H;2-H
+play,7,1,rossd001,12,FFF*BS,K
+play,7,1,strop001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,7,1,lastt001,20,.*BBX,7/F5F
+play,8,0,norrd001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,8,0,norrd001,32,.CSBBBB,W
+play,8,0,uptob001,00,X,S7/L.1-2
+play,8,0,wallb001,12,CBFFS,K
+play,8,0,pirej001,20,BBX,S9/G.2-3;1-2
+play,8,0,rosaa001,00,,NP
+sub,warra001,"Adam Warren",1,9,1
+play,8,0,rosaa001,12,.CFBS,K
+play,8,0,perdl002,00,,NP
+sub,dicka001,"Alex Dickerson",0,9,11
+play,8,0,dicka001,02,.CTX,HR/89/F.3-H;2-H;1-H
+play,8,0,jay-j001,31,BBBCX,43/G
+play,8,1,fowld001,00,,NP
+sub,quack001,"Kevin Quackenbush",0,9,1
+play,8,1,fowld001,32,.BCBCFBFC,K
+play,8,1,heywj001,10,BX,8/F
+play,8,1,bryak001,12,BCCX,43/G
+play,9,0,myerw001,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,9,0,myerw001,12,.BFSC,K
+play,9,0,kempm001,22,FFBBS,K
+play,9,0,norrd001,11,CBX,63/G
+data,er,vargc002,6
+data,er,perdl002,2
+data,er,quack001,0
+data,er,lestj001,3
+data,er,cahit001,0
+data,er,richc002,0
+data,er,strop001,0
+data,er,grimj002,3
+data,er,warra001,1
+data,er,rondh001,0
+id,CHN201605111
+version,2
+info,visteam,SDN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/11
+info,number,1
+info,starttime,12:06PM
+info,daynight,day
+info,usedh,false
+info,umphome,basnt901
+info,ump1b,sches901
+info,ump2b,danlk901
+info,ump3b,fleta901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,51
+info,winddir,fromrf
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,195
+info,attendance,34508
+info,wp,villc001
+info,lp,strop001
+info,save,rodnf001
+start,jankt001,"Travis Jankowski",0,1,8
+start,myerw001,"Wil Myers",0,2,3
+start,kempm001,"Matt Kemp",0,3,9
+start,wallb001,"Brett Wallace",0,4,5
+start,norrd001,"Derek Norris",0,5,2
+start,dicka001,"Alex Dickerson",0,6,7
+start,pirej001,"Jose Pirela",0,7,4
+start,rosaa001,"Adam Rosales",0,8,6
+start,rea-c001,"Colin Rea",0,9,1
+start,zobrb001,"Ben Zobrist",1,1,4
+start,heywj001,"Jason Heyward",1,2,8
+start,bryak001,"Kris Bryant",1,3,9
+start,rizza001,"Anthony Rizzo",1,4,3
+start,solej001,"Jorge Soler",1,5,7
+start,baezj001,"Javier Baez",1,6,5
+start,russa002,"Addison Russell",1,7,6
+start,fedet001,"Tim Federowicz",1,8,2
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,jankt001,32,BBFBCB,W
+play,1,0,myerw001,10,B11>B,SB2
+play,1,0,myerw001,22,B11>B.CSFX,E5/TH/G.2-H;B-2
+play,1,0,kempm001,00,X,S8/L.2-H(UR)
+play,1,0,wallb001,22,BCS*BS,K
+play,1,0,norrd001,21,CBBX,S7/L.1-2
+play,1,0,dicka001,21,B*BSX,13/G-.2-3;1-2
+play,1,0,pirej001,01,CX,63/G-
+play,1,1,zobrb001,31,BBBCX,S7/L
+play,1,1,heywj001,31,BBFB1B,W.1-2
+play,1,1,bryak001,21,BCBX,9/F
+play,1,1,rizza001,21,BCBX,S8/G.2-H;1-3
+play,1,1,solej001,01,FX,3/P
+play,1,1,baezj001,01,CX,63/G
+play,2,0,rosaa001,11,CBX,53/G
+play,2,0,rea-c001,12,BFCFX,7/F
+play,2,0,jankt001,11,BSX,13/G-
+play,2,1,russa002,01,CX,S9/L
+play,2,1,fedet001,11,BFX,343/G.1-2
+play,2,1,hendk001,02,CFFS,K
+play,2,1,zobrb001,02,CCX,S9/L.2-H
+play,2,1,heywj001,12,>LB1F>B,CS2(26)
+play,3,0,myerw001,22,CBCBX,S8/G
+play,3,0,kempm001,01,C1X,54(1)3/GDP
+play,3,0,wallb001,22,BCFBH,HP
+play,3,0,norrd001,20,B*BX,S5/G.1-2
+play,3,0,dicka001,00,X,43/G
+play,3,1,heywj001,12,FBFFS,K
+play,3,1,bryak001,10,BX,8/L
+play,3,1,rizza001,32,BFBBFB,W
+play,3,1,solej001,01,CX,9/L
+play,4,0,pirej001,12,CBCS,K23
+play,4,0,rosaa001,01,CX,S8/F-
+play,4,0,rea-c001,01,1L>X,34/BG/SH.1-2
+play,4,0,jankt001,12,BFSFS,K
+play,4,1,baezj001,22,BFBFFFFH,HP
+play,4,1,russa002,20,BB1X,D9/L.1-H
+play,4,1,fedet001,32,CBBBSFFX,D7/L.2-H
+play,4,1,hendk001,00,X,14/BG/SH.2-3
+play,4,1,zobrb001,32,BC*BBCB,W
+play,4,1,heywj001,11,BCX,8/F
+play,4,1,bryak001,01,FX,8/L
+play,5,0,myerw001,21,CBBX,63/G
+play,5,0,kempm001,12,CBFS,K
+play,5,0,wallb001,32,BBBCCC,K
+play,5,1,rizza001,02,CLX,9/F
+play,5,1,solej001,31,BBBFX,D8/L
+play,5,1,baezj001,32,BBFSBX,E5/TH/G.2-3;B-2
+play,5,1,russa002,30,IIII,IW
+play,5,1,fedet001,22,SS*BBS,K
+play,5,1,hendk001,11,BTX,53/G
+play,6,0,norrd001,12,CBFS,K
+play,6,0,dicka001,12,BSSFC,K
+play,6,0,pirej001,10,BX,6/P
+play,6,1,zobrb001,00,,NP
+sub,villc001,"Carlos Villanueva",0,6,1
+play,6,1,zobrb001,00,,NP
+sub,blasj001,"Jabari Blash",0,9,7
+play,6,1,zobrb001,32,..BCBBFX,8/F
+play,6,1,heywj001,20,BBX,S5/G.B-2(E5/TH)
+play,6,1,bryak001,01,SX,63/G
+play,6,1,rizza001,30,IIII,IW
+play,6,1,solej001,02,CFX,3/P
+play,7,0,rosaa001,22,SBBFC,K
+play,7,0,blasj001,11,FBX,53/G
+play,7,0,jankt001,00,X,S5/BG
+play,7,0,myerw001,00,,NP
+sub,heywj001,"Jason Heyward",1,2,9
+play,7,0,myerw001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,7,0,myerw001,00,,NP
+sub,strop001,"Pedro Strop",1,5,1
+play,7,0,myerw001,00,,NP
+sub,fowld001,"Dexter Fowler",1,9,8
+play,7,0,myerw001,10,....BB,WP.1-2
+play,7,0,myerw001,31,....BB.SBX,S5/G.2-H(E5/TH)(NR)
+play,7,0,kempm001,32,BBCBF>F>B,W.1-2
+play,7,0,wallb001,12,C*BFX,HR/78/F.2-H;1-H
+play,7,0,norrd001,22,CBSBX,S7/L
+play,7,0,villc001,00,,NP
+sub,jay-j001,"Jon Jay",0,6,11
+play,7,0,jay-j001,32,.FBBSFB*B,W.1-2
+play,7,0,pirej001,00,,NP
+sub,ramin001,"Neil Ramirez",1,5,1
+play,7,0,pirej001,12,.*BSCS,K
+play,7,1,baezj001,00,,NP
+sub,jankt001,"Travis Jankowski",0,1,7
+play,7,1,baezj001,00,,NP
+sub,jay-j001,"Jon Jay",0,6,8
+play,7,1,baezj001,00,,NP
+sub,buchr001,"Ryan Buchter",0,9,1
+play,7,1,baezj001,00,...X,7/F
+play,7,1,russa002,32,CBBSBFC,K
+play,7,1,fedet001,32,BBCFBX,2/P5F
+play,8,0,rosaa001,00,X,S6/G
+play,8,0,buchr001,00,,NP
+sub,uptob001,"Melvin Upton",0,9,11
+play,8,0,uptob001,32,.C1B1FFB+1*B>B,W.1-2
+play,8,0,jankt001,31,BLB+2BB,W.2-3;1-2
+play,8,0,myerw001,02,CSS,K
+play,8,0,kempm001,12,FS*BFX,7/L/SF.3-H;2-3(E7/TH);1-2
+play,8,0,wallb001,30,IIII,IW
+play,8,0,norrd001,20,BBX,9/L
+play,8,1,fowld001,00,,NP
+sub,maurb001,"Brandon Maurer",0,9,1
+play,8,1,fowld001,11,.CBX,S9/L
+play,8,1,zobrb001,31,BSBBB,W.1-2
+play,8,1,heywj001,22,BF*BFS,K
+play,8,1,bryak001,10,BX,3/P/IF
+play,8,1,rizza001,11,*BSX,7/F
+play,9,0,jay-j001,00,,NP
+sub,richc002,"Clayton Richard",1,5,1
+play,9,0,jay-j001,00,.X,13/G
+play,9,0,pirej001,22,CBCBX,43/G
+play,9,0,rosaa001,21,BCBX,8/F
+play,9,1,richc002,00,,NP
+sub,rodnf001,"Fernando Rodney",0,7,1
+play,9,1,richc002,00,,NP
+sub,rosaa001,"Adam Rosales",0,8,4
+play,9,1,richc002,00,,NP
+sub,ramia003,"Alexei Ramirez",0,9,6
+play,9,1,richc002,00,,NP
+sub,kalir001,"Ryan Kalish",1,5,11
+play,9,1,kalir001,22,....CSBBX,3/G
+play,9,1,baezj001,10,BX,7/L
+play,9,1,russa002,21,BCBX,63/G
+data,er,rea-c001,4
+data,er,villc001,0
+data,er,buchr001,0
+data,er,maurb001,0
+data,er,rodnf001,0
+data,er,hendk001,2
+data,er,strop001,3
+data,er,ramin001,1
+data,er,richc002,0
+id,CHN201605112
+version,2
+info,visteam,SDN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/11
+info,number,2
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,westj901
+info,ump1b,danlk901
+info,ump2b,fleta901
+info,ump3b,sches901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,52
+info,winddir,ltor
+info,windspeed,4
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,165
+info,attendance,37828
+info,wp,pomed001
+info,lp,lackj001
+info,save,rodnf001
+start,jay-j001,"Jon Jay",0,1,8
+start,myerw001,"Wil Myers",0,2,3
+start,kempm001,"Matt Kemp",0,3,9
+start,uptob001,"Melvin Upton",0,4,7
+start,ramia003,"Alexei Ramirez",0,5,6
+start,bethc001,"Christian Bethancourt",0,6,2
+start,pirej001,"Jose Pirela",0,7,4
+start,rosaa001,"Adam Rosales",0,8,5
+start,pomed001,"Drew Pomeranz",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,solej001,"Jorge Soler",1,5,7
+start,baezj001,"Javier Baez",1,6,6
+start,lastt001,"Tommy La Stella",1,7,4
+start,rossd001,"David Ross",1,8,2
+start,lackj001,"John Lackey",1,9,1
+play,1,0,jay-j001,02,FFFC,K
+play,1,0,myerw001,12,CFBX,7/F
+play,1,0,kempm001,22,FFFBBX,4/P
+play,1,1,fowld001,12,FFBFC,K
+play,1,1,heywj001,01,CX,S7/L-
+play,1,1,bryak001,11,CBX,S7/G.1-2
+play,1,1,rizza001,02,CFX,46(1)3/GDP
+play,2,0,uptob001,32,FBBFBFS,K
+play,2,0,ramia003,00,X,13/G
+play,2,0,bethc001,12,FFBFFX,4/P
+play,2,1,solej001,32,BSFFBFFBFC,K
+play,2,1,baezj001,32,BFBMBB,W
+play,2,1,lastt001,01,S>X,13/G-.1-2
+play,2,1,rossd001,12,FBCFS,K
+play,3,0,pirej001,21,CBBX,63/G
+play,3,0,rosaa001,32,STBBFBX,9/F
+play,3,0,pomed001,02,FFS,K
+play,3,1,lackj001,12,BFFC,K
+play,3,1,fowld001,12,BSSS,K
+play,3,1,heywj001,12,CFBFT,K
+play,4,0,jay-j001,01,CX,7/F
+play,4,0,myerw001,32,CBFBBFX,9/L
+play,4,0,kempm001,00,X,8/F
+play,4,1,bryak001,01,CX,8/L
+play,4,1,rizza001,22,BFCBX,63/G
+play,4,1,solej001,32,FBBBTC,K
+play,5,0,uptob001,22,SCBBX,63/G-
+play,5,0,ramia003,32,CFFBBBFFFX,43/G
+play,5,0,bethc001,10,BX,HR/7/F
+play,5,0,pirej001,02,SFX,S3/G
+play,5,0,rosaa001,00,1>X,13/G-
+play,5,1,baezj001,02,CSFS,K
+play,5,1,lastt001,22,BCBFX,S8/L
+play,5,1,rossd001,32,B*BBFFB,W.1-2
+play,5,1,lackj001,02,FCFS,K
+play,5,1,fowld001,01,FX,8/L
+play,6,0,pomed001,02,CSFC,K
+play,6,0,jay-j001,12,BFFS,K
+play,6,0,myerw001,32,FSBBFBX,9/F
+play,6,1,heywj001,12,CBFX,7/L
+play,6,1,bryak001,32,FBBBFB,W
+play,6,1,rizza001,11,FBX,3/G+.1-2
+play,6,1,solej001,22,CS*B*BS,K
+play,7,0,kempm001,11,BSX,63/G
+play,7,0,uptob001,00,X,8/F
+play,7,0,ramia003,22,FBFFBS,K
+play,7,1,baezj001,00,,NP
+sub,quack001,"Kevin Quackenbush",0,9,1
+play,7,1,baezj001,32,.CCBFBBS,K
+play,7,1,lastt001,22,TBCFBX,7/F
+play,7,1,rossd001,21,BFBX,8/F
+play,8,0,bethc001,12,BCFFX,S8/G
+play,8,0,pirej001,01,FX,53/BG/SH.1-2
+play,8,0,rosaa001,10,BX,13/G
+play,8,0,quack001,00,,NP
+sub,wallb001,"Brett Wallace",0,9,11
+play,8,0,wallb001,12,.BCFFS,K
+play,8,1,lackj001,00,,NP
+sub,handb001,"Brad Hand",0,9,1
+play,8,1,lackj001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,9,11
+play,8,1,zobrb001,22,..BBCFC,K
+play,8,1,fowld001,22,CBBFS,K
+play,8,1,heywj001,30,BBBB,W
+play,8,1,bryak001,11,BCX,E6/P.1-3
+play,8,1,rizza001,30,BB*BB,W.1-2
+play,8,1,solej001,22,BSFBS,K
+play,9,0,jay-j001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,9,0,jay-j001,00,,NP
+sub,woodt004,"Travis Wood",1,5,1
+play,9,0,jay-j001,00,,NP
+sub,lastt001,"Tommy La Stella",1,7,5
+play,9,0,jay-j001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,9,4
+play,9,0,jay-j001,00,....X,7/L
+play,9,0,myerw001,00,,NP
+sub,rondh001,"Hector Rondon",1,5,1
+play,9,0,myerw001,12,.SBCC,K
+play,9,0,kempm001,12,BCSX,31/G
+play,9,1,baezj001,00,,NP
+sub,rodnf001,"Fernando Rodney",0,3,1
+play,9,1,baezj001,00,,NP
+sub,jankt001,"Travis Jankowski",0,9,9
+play,9,1,baezj001,12,..BCSX,S8/G
+play,9,1,lastt001,21,BBFX,54(1)/FO/G
+play,9,1,rossd001,00,,NP
+sub,kalir001,"Ryan Kalish",1,8,11
+play,9,1,kalir001,22,.CB1F*B>X,43/G.1-2
+play,9,1,zobrb001,32,CBBBFFX,13/G
+data,er,pomed001,0
+data,er,quack001,0
+data,er,handb001,0
+data,er,rodnf001,0
+data,er,lackj001,1
+data,er,woodt004,0
+data,er,rondh001,0
+id,CHN201605130
+version,2
+info,visteam,PIT
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/13
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,hobep901
+info,ump1b,knigb901
+info,ump2b,ticht901
+info,ump3b,welkb901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,65
+info,winddir,torf
+info,windspeed,11
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,175
+info,attendance,37479
+info,wp,hammj002
+info,lp,lirif001
+info,save,
+start,jasoj001,"John Jaso",0,1,3
+start,mccua001,"Andrew McCutchen",0,2,8
+start,polag001,"Gregory Polanco",0,3,9
+start,marts002,"Starling Marte",0,4,7
+start,cervf001,"Francisco Cervelli",0,5,2
+start,kangj001,"Jung Ho Kang",0,6,5
+start,harrj002,"Josh Harrison",0,7,4
+start,mercj002,"Jordy Mercer",0,8,6
+start,lirif001,"Francisco Liriano",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,solej001,"Jorge Soler",1,6,7
+start,russa002,"Addison Russell",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,jasoj001,02,CCS,K
+play,1,0,mccua001,00,X,S7/G
+play,1,0,polag001,12,1C1BTT,K
+play,1,0,marts002,01,CX,63/G
+play,1,1,fowld001,12,CBSS,K
+play,1,1,heywj001,32,BCCBBB,W
+play,1,1,bryak001,11,1SBX,8/L
+play,1,1,rizza001,01,CX,53/G
+play,2,0,cervf001,31,CBBBX,63/G
+play,2,0,kangj001,12,CBSS,K
+play,2,0,harrj002,00,X,S5/BG
+play,2,0,mercj002,00,>B,SB2
+play,2,0,mercj002,20,>B.BX,63/G
+play,2,1,zobrb001,02,CSS,K
+play,2,1,solej001,12,CBCX,S9/L
+play,2,1,russa002,20,BBX,46(1)/FO/G
+play,2,1,rossd001,10,BX,S8/L.1-2
+play,2,1,hammj002,02,FSS,K
+play,3,0,lirif001,01,SX,S8/G
+play,3,0,jasoj001,00,X,46(1)3/GDP
+play,3,0,mccua001,01,CX,D8/L
+play,3,0,polag001,30,BBBB,W
+play,3,0,marts002,22,SBS*BFS,K
+play,3,1,fowld001,12,LFFBS,K
+play,3,1,heywj001,30,BBBB,W
+play,3,1,bryak001,30,BBBX,4/P
+play,3,1,rizza001,12,CBCS,K
+play,4,0,cervf001,22,BCBCC,K
+play,4,0,kangj001,12,BCCX,8/L
+play,4,0,harrj002,32,BBFBCFFX,53/G-
+play,4,1,zobrb001,01,CX,S7/L
+play,4,1,solej001,32,BBSSBB,W.1-2
+play,4,1,russa002,32,BS*BSBX,HR/7/F.2-H;1-H
+play,4,1,rossd001,11,BFX,9/F
+play,4,1,hammj002,31,BBFBX,S8/L
+play,4,1,fowld001,11,BFX,64(1)3/GDP
+play,5,0,mercj002,01,CX,63/G-
+play,5,0,lirif001,22,FCBBX,31/G
+play,5,0,jasoj001,10,BX,S8/G
+play,5,0,mccua001,00,X,3/P3F
+play,5,1,heywj001,11,BCX,S8/L
+play,5,1,bryak001,11,BSX,HR/78/L.1-H
+play,5,1,rizza001,10,BX,D8/L
+play,5,1,zobrb001,31,BC*BBB,W
+play,5,1,solej001,12,SSBS,K
+play,5,1,russa002,32,BCBSBC,K
+play,5,1,rossd001,20,BBX,HR/78/L.2-H;1-H
+play,5,1,hammj002,00,,NP
+sub,voger001,"Ryan Vogelsong",0,9,1
+play,5,1,hammj002,22,.BSSBS,K
+play,6,0,polag001,22,CBBFX,D9/L
+play,6,0,marts002,21,CBBX,S9/L.2-3
+play,6,0,cervf001,12,SB1F>B,SB2.3-H(E2/TH)(NR);1-3
+play,6,0,cervf001,22,SB1F>B.X,S5/G-.3-H(UR)
+play,6,0,kangj001,12,*BCSS,K
+play,6,0,harrj002,00,X,64(1)3/GDP
+play,6,1,fowld001,11,BSX,31/G
+play,6,1,heywj001,22,CCBFBX,7/L
+play,6,1,bryak001,12,CSBS,K
+play,7,0,mercj002,32,CBSBBFFFC,K
+play,7,0,voger001,00,,NP
+sub,rodrs002,"Sean Rodriguez",0,9,11
+play,7,0,rodrs002,22,.SSBBS,K
+play,7,0,jasoj001,31,BBCBB,W
+play,7,0,mccua001,00,,NP
+sub,warra001,"Adam Warren",1,9,1
+play,7,0,mccua001,22,.BSBCX,53/G
+play,7,1,rizza001,00,,NP
+sub,hughj001,"Jared Hughes",0,8,1
+play,7,1,rizza001,00,,NP
+sub,rodrs002,"Sean Rodriguez",0,9,6
+play,7,1,rizza001,02,..FCX,7/F
+play,7,1,zobrb001,32,CCBBBX,43/G
+play,7,1,solej001,32,BSBBCX,8/F
+play,8,0,polag001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,8,0,polag001,00,,NP
+sub,richc002,"Clayton Richard",1,6,1
+play,8,0,polag001,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,8,0,polag001,21,...CBBX,D9/L
+play,8,0,marts002,00,,NP
+sub,cahit001,"Trevor Cahill",1,6,1
+play,8,0,marts002,12,.BFCX,S4/G-.2-3
+play,8,0,cervf001,01,C>B,SB2
+play,8,0,cervf001,12,C>B.SFFFX,9/F
+play,8,0,kangj001,12,BCSX,8/F
+play,8,0,harrj002,11,BSX,53/G
+play,8,1,russa002,00,,NP
+sub,stewc001,"Chris Stewart",0,5,2
+play,8,1,russa002,00,,NP
+sub,camia001,"Arquimedes Caminero",0,8,1
+play,8,1,russa002,22,..CFBFBX,8/F
+play,8,1,rossd001,22,BCBFX,S9/L
+play,8,1,baezj001,00,X,9/L
+play,8,1,fowld001,01,SB,PB.1-2
+play,8,1,fowld001,21,SB.BX,D9/L.2-H(UR)
+play,8,1,heywj001,32,BBBCCX,63/G
+play,9,0,camia001,00,,NP
+sub,figuc001,"Cole Figueroa",0,8,11
+play,9,0,figuc001,01,.CX,31/G
+play,9,0,rodrs002,32,BCBSBB,W
+play,9,0,jasoj001,00,>C,DI.1-2
+play,9,0,jasoj001,02,>C.CX,53/G
+play,9,0,mccua001,10,BX,HR/78/F.2-H
+play,9,0,polag001,31,BFBBB,W
+play,9,0,marts002,00,>C,DI.1-2
+play,9,0,marts002,12,>C.BFX,8/L
+data,er,lirif001,8
+data,er,voger001,0
+data,er,hughj001,0
+data,er,camia001,0
+data,er,hammj002,1
+data,er,warra001,0
+data,er,richc002,0
+data,er,cahit001,2
+id,CHN201605140
+version,2
+info,visteam,PIT
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/14
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,knigb901
+info,ump1b,ticht901
+info,ump2b,welkb901
+info,ump3b,hobep901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,speaa701
+info,temp,44
+info,winddir,ltor
+info,windspeed,17
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,162
+info,attendance,40953
+info,wp,arrij001
+info,lp,lockj001
+info,save,
+start,jasoj001,"John Jaso",0,1,3
+start,mccua001,"Andrew McCutchen",0,2,8
+start,polag001,"Gregory Polanco",0,3,9
+start,marts002,"Starling Marte",0,4,7
+start,cervf001,"Francisco Cervelli",0,5,2
+start,kangj001,"Jung Ho Kang",0,6,5
+start,harrj002,"Josh Harrison",0,7,4
+start,mercj002,"Jordy Mercer",0,8,6
+start,lockj001,"Jeff Locke",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,solej001,"Jorge Soler",1,6,7
+start,russa002,"Addison Russell",1,7,6
+start,montm001,"Miguel Montero",1,8,2
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,jasoj001,02,CCX,43/G
+play,1,0,mccua001,11,BSX,13/G-
+play,1,0,polag001,21,BBTX,8/F
+play,1,1,fowld001,32,BBFCBX,8/L
+play,1,1,heywj001,10,BX,8/F
+play,1,1,bryak001,22,BFSBX,9/F
+play,2,0,marts002,12,CTBFFS,K
+play,2,0,cervf001,21,CBBX,9/L
+play,2,0,kangj001,31,CBBBB,W
+play,2,0,harrj002,11,FBB,PB.1-2
+play,2,0,harrj002,22,FBB.CFS,K
+play,2,1,rizza001,02,CCX,7/F
+play,2,1,zobrb001,21,BBCX,S7/L
+play,2,1,solej001,01,CX,8/F
+play,2,1,russa002,00,X,8/L
+play,3,0,mercj002,00,X,8/F
+play,3,0,lockj001,21,BBCX,43/G
+play,3,0,jasoj001,02,CFS,K
+play,3,1,montm001,11,SBX,41/G
+play,3,1,arrij001,12,BCCC,K
+play,3,1,fowld001,22,FFBBX,9/F
+play,4,0,mccua001,32,CBBCBFFFFX,D8/L
+play,4,0,polag001,11,BCX,S8/L.2-3
+play,4,0,marts002,11,*B1>F>C,SB2
+play,4,0,marts002,12,*B1>F>C.S,K
+play,4,0,cervf001,00,X,S8/L.3-H;2-H;B-2(TH)
+play,4,0,kangj001,00,B,WP.2-3
+play,4,0,kangj001,10,B.H,HP
+play,4,0,harrj002,00,X,146(1)3/GDP
+play,4,1,heywj001,12,BCCX,S4/G-
+play,4,1,bryak001,32,CFBB1BB,W.1-2
+play,4,1,rizza001,01,CX,HR/89/F.2-H;1-H
+play,4,1,zobrb001,32,BBCCBFB,W
+com,"ej,searr001,C,knigb901,Balls and strikes"
+com,"Pirates Pitching Coach Ray Searage ejected by HP umpire Brian Knight"
+play,4,1,solej001,02,.SCS,K
+play,4,1,russa002,02,FFX,9/L
+play,4,1,montm001,31,BBBFX,E4/G.1-2
+play,4,1,arrij001,32,SBBCB>X,8/F
+play,5,0,mercj002,11,BCX,53/G
+play,5,0,lockj001,30,BBBB,W
+play,5,0,jasoj001,12,F*BFC,K
+play,5,0,mccua001,02,SFC,K
+play,5,1,fowld001,22,BFSBX,13/G-
+play,5,1,heywj001,20,BBX,S7/G+
+play,5,1,bryak001,02,CFS,K
+play,5,1,rizza001,20,BBX,9/F
+play,6,0,polag001,22,BSFBS,K
+play,6,0,marts002,02,LFC,K
+play,6,0,cervf001,10,BX,53/G
+play,6,1,zobrb001,21,BCBX,S9/L
+play,6,1,solej001,00,X,4/P
+play,6,1,russa002,11,CBX,HR/7/F.1-H
+play,6,1,montm001,02,SFH,HP
+play,6,1,arrij001,00,,NP
+sub,hughj001,"Jared Hughes",0,9,1
+play,6,1,arrij001,32,.C*BBCBFB,W.1-2
+play,6,1,fowld001,11,SBX,S7/L-.2-H;1-2
+play,6,1,heywj001,31,CB*B*BB,W.2-3;1-2
+play,6,1,bryak001,02,SFS,K
+play,6,1,rizza001,10,*BX,43/G
+play,7,0,kangj001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,7,0,kangj001,00,,NP
+sub,baezj001,"Javier Baez",1,6,5
+play,7,0,kangj001,21,..CBBX,9/F
+play,7,0,harrj002,22,BFFBC,K
+play,7,0,mercj002,10,BX,2/P2F
+play,7,1,zobrb001,00,,NP
+sub,schua001,"A.J. Schugel",0,8,1
+play,7,1,zobrb001,00,,NP
+sub,rodrs002,"Sean Rodriguez",0,9,6
+play,7,1,zobrb001,32,..BBBCFB,W
+play,7,1,baezj001,02,CFC,K
+play,7,1,russa002,10,BX,7/F
+play,7,1,montm001,12,BFFB,PB.1-2
+play,7,1,montm001,22,BFFB.S,K
+play,8,0,rodrs002,22,CBBFC,K
+play,8,0,jasoj001,02,CSX,43/G
+play,8,0,mccua001,22,CBBSC,K
+play,8,1,arrij001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,8,1,lastt001,22,.BBFSS,K
+play,8,1,fowld001,12,CSBFFX,S8/L
+play,8,1,heywj001,21,*BBFX,S9/L.1-3
+play,8,1,bryak001,10,*BX,S7/L.3-H;1-3;BX2(74)
+play,8,1,rizza001,12,BCFX,S8/G.3-H
+play,8,1,zobrb001,11,CBX,4/P
+play,9,0,polag001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,9,0,polag001,22,.BCCBS,K23
+play,9,0,marts002,20,BBX,9/F
+play,9,0,cervf001,32,CBBCBX,53/G
+data,er,lockj001,6
+data,er,hughj001,0
+data,er,schua001,2
+data,er,arrij001,2
+data,er,grimj002,0
+id,CHN201605150
+version,2
+info,visteam,PIT
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/15
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,ticht901
+info,ump1b,welkb901
+info,ump2b,hobep901
+info,ump3b,knigb901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,45
+info,winddir,fromrf
+info,windspeed,11
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,175
+info,attendance,40814
+info,wp,coleg001
+info,lp,lestj001
+info,save,melam001
+start,mercj002,"Jordy Mercer",0,1,6
+start,mccua001,"Andrew McCutchen",0,2,8
+start,freed001,"David Freese",0,3,3
+start,marts002,"Starling Marte",0,4,7
+start,cervf001,"Francisco Cervelli",0,5,2
+start,kangj001,"Jung Ho Kang",0,6,5
+start,harrj002,"Josh Harrison",0,7,4
+start,rodrs002,"Sean Rodriguez",0,8,9
+start,coleg001,"Gerrit Cole",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,7
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,russa002,"Addison Russell",1,6,6
+start,baezj001,"Javier Baez",1,7,5
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,mercj002,21,BFBX,63/G
+play,1,0,mccua001,11,CBX,3/P
+play,1,0,freed001,30,BBBB,W
+play,1,0,marts002,22,BCS*BC,K
+play,1,1,fowld001,32,BBFFFBFX,D4/P
+play,1,1,heywj001,12,FBCT,K
+play,1,1,bryak001,31,BFBBX,3/P3F
+play,1,1,rizza001,12,FF*BX,8/F
+play,2,0,cervf001,30,BBBB,W
+play,2,0,kangj001,22,BCCF*BFFC,K
+play,2,0,harrj002,00,X,4/P
+play,2,0,rodrs002,22,C*BBCC,K
+play,2,1,zobrb001,12,CCBC,K
+play,2,1,russa002,00,X,S6/G+
+play,2,1,baezj001,00,1X,54(1)/FO/G
+play,2,1,rossd001,02,FF1X,8/F
+play,3,0,coleg001,12,CBSS,K
+play,3,0,mercj002,32,CBBFBFFFX,63/G
+play,3,0,mccua001,01,CX,63/G
+play,3,1,lestj001,22,CFFFBBX,31/G
+play,3,1,fowld001,00,X,31/G
+play,3,1,heywj001,22,CBFBC,K
+play,4,0,freed001,12,BFFS,K
+play,4,0,marts002,12,LBSFX,9/F
+play,4,0,cervf001,00,X,53/G
+play,4,1,bryak001,10,BX,53/G
+play,4,1,rizza001,01,CX,7/F
+play,4,1,zobrb001,11,FBX,D9/F
+play,4,1,russa002,22,BFSBT,K
+play,5,0,kangj001,22,BFFBX,6/L
+play,5,0,harrj002,22,BBFFX,53/G
+play,5,0,rodrs002,22,BBSFC,K
+play,5,1,baezj001,20,BBX,8/F
+play,5,1,rossd001,22,FLBFBFS,K
+play,5,1,lestj001,10,BX,53/G
+play,6,0,coleg001,12,BSFFS,K
+play,6,0,mercj002,32,BFCBBX,7/F
+play,6,0,mccua001,32,FSBBBS,K
+play,6,1,fowld001,22,BSFBC,K
+play,6,1,heywj001,02,CFX,3/P3F
+play,6,1,bryak001,22,BCSBX,63/G-
+play,7,0,freed001,22,CBFBFX,13/G-
+play,7,0,marts002,02,FSFX,S9/G
+play,7,0,cervf001,11,CB+1>S,SB2
+play,7,0,cervf001,22,CB+1>S.BS,K
+play,7,0,kangj001,11,SBX,D9/F.2-H
+play,7,0,harrj002,00,,NP
+sub,warra001,"Adam Warren",1,9,1
+play,7,0,harrj002,32,.CBBBCB,W
+play,7,0,rodrs002,00,,NP
+sub,polag001,"Gregory Polanco",0,8,11
+play,7,0,polag001,31,.B+2CBII,IW.2-3;1-2
+play,7,0,coleg001,10,BX,64(1)/FO/G
+play,7,1,rizza001,00,,NP
+sub,polag001,"Gregory Polanco",0,8,9
+play,7,1,rizza001,00,.X,8/F
+play,7,1,zobrb001,31,BBBCX,9/F
+play,7,1,russa002,00,X,6/L
+play,8,0,mercj002,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,8,0,mercj002,10,.BX,S9/L
+play,8,0,mccua001,02,CFX,53/G.1-2
+play,8,0,freed001,22,BS*BCFS,K
+play,8,0,marts002,10,*BX,43/G
+play,8,1,baezj001,00,X,23/BG
+play,8,1,rossd001,00,,NP
+sub,lastt001,"Tommy La Stella",1,8,11
+play,8,1,lastt001,12,.CBSX,8/F
+play,8,1,strop001,00,,NP
+sub,montm001,"Miguel Montero",1,9,11
+play,8,1,montm001,02,.FSS,K
+play,9,0,cervf001,00,,NP
+sub,rondh001,"Hector Rondon",1,8,1
+play,9,0,cervf001,00,,NP
+sub,montm001,"Miguel Montero",1,9,2
+play,9,0,cervf001,12,..CFFBC,K
+play,9,0,kangj001,32,BCBCBFX,HR/78/F
+play,9,0,harrj002,21,SBBX,S9/F
+play,9,0,polag001,32,111BBBC>F>B,W.1-2
+play,9,0,coleg001,00,,NP
+sub,joycm001,"Matthew Joyce",0,9,11
+play,9,0,joycm001,00,,NP
+sub,woodt004,"Travis Wood",1,8,1
+play,9,0,joycm001,01,..C>X,3/G.2-3;1-2
+play,9,0,mercj002,00,,NP
+sub,grimj002,"Justin Grimm",1,8,1
+play,9,0,mercj002,31,.B*B*BCB,W
+play,9,0,mccua001,02,FFS,K23
+play,9,1,fowld001,00,,NP
+sub,melam001,"Mark Melancon",0,9,1
+play,9,1,fowld001,31,.CBBBB,W
+play,9,1,heywj001,11,BCX,S9/L.1-3
+play,9,1,bryak001,00,X,8/F
+play,9,1,rizza001,01,CX,9/F/SF.3-H
+play,9,1,zobrb001,12,CBCF>B,SB2
+play,9,1,zobrb001,32,CBCF>B.BFX,43/G
+data,er,coleg001,0
+data,er,melam001,1
+data,er,lestj001,1
+data,er,warra001,0
+data,er,strop001,0
+data,er,rondh001,1
+data,er,woodt004,0
+data,er,grimj002,0
+id,CHN201605270
+version,2
+info,visteam,PHI
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/27
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,davib902
+info,ump1b,barrl901
+info,ump2b,barbs901
+info,ump3b,scotd901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,76
+info,winddir,tolf
+info,windspeed,8
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,184
+info,attendance,38941
+info,wp,lestj001
+info,lp,morga001
+info,save,
+start,herro001,"Odubel Herrera",0,1,8
+start,galvf001,"Freddy Galvis",0,2,6
+start,franm004,"Maikel Franco",0,3,5
+start,joset001,"Tommy Joseph",0,4,3
+start,ruizc001,"Carlos Ruiz",0,5,2
+start,hernc005,"Cesar Hernandez",0,6,4
+start,goedt001,"Tyler Goeddel",0,7,7
+start,morga001,"Adam Morgan",0,8,1
+start,bourp001,"Peter Bourjos",0,9,9
+start,fowld001,"Dexter Fowler",1,1,8
+start,zobrb001,"Ben Zobrist",1,2,4
+start,bryak001,"Kris Bryant",1,3,3
+start,solej001,"Jorge Soler",1,4,7
+start,szczm001,"Matt Szczur",1,5,9
+start,russa002,"Addison Russell",1,6,6
+start,baezj001,"Javier Baez",1,7,5
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,herro001,32,CBSFBBFFX,7/F
+play,1,0,galvf001,12,FBSFS,K
+play,1,0,franm004,12,CFBFS,K
+play,1,1,fowld001,20,BBX,9/F
+play,1,1,zobrb001,32,BCBBCX,D7/G
+play,1,1,bryak001,32,BSSBBFX,63/G
+play,1,1,solej001,22,SB*BSX,S7/G.2-H
+play,1,1,szczm001,01,1F1X,4/P
+play,2,0,joset001,01,FX,S8/L
+play,2,0,ruizc001,00,X,9/F
+play,2,0,hernc005,10,BX,S8/G.1-2
+play,2,0,goedt001,20,BBX,8/F
+play,2,0,morga001,00,X,64(1)/FO/G
+play,2,1,russa002,32,FBBBFX,43/G
+play,2,1,baezj001,21,BBSX,63/G
+play,2,1,rossd001,12,FCBS,K
+play,3,0,bourp001,01,CX,S7/G
+play,3,0,herro001,32,CBBFFBS,K
+play,3,0,galvf001,10,BX,E8/F.1-3(E5);B-2
+play,3,0,franm004,02,FSX,9/F/SF.3-H(UR);2-3
+play,3,0,joset001,12,FBFC,K
+play,3,1,lestj001,12,CSBS,K
+play,3,1,fowld001,00,X,563/G
+play,3,1,zobrb001,02,CCX,S2/G-.B-2(E2/TH)
+play,3,1,bryak001,01,CX,8/F
+play,4,0,ruizc001,21,CBBX,53/G
+play,4,0,hernc005,02,CLS,K
+play,4,0,goedt001,12,SBSFX,S48/G
+play,4,0,morga001,02,CTS,K
+play,4,1,solej001,12,BSCX,HR/78/F
+play,4,1,szczm001,02,SFX,7/F
+play,4,1,russa002,32,CBBFBFFB,W
+play,4,1,baezj001,22,1C*BBS1X,S7/L.1-2
+play,4,1,rossd001,10,*BX,HR/7/F.2-H;1-H
+play,4,1,lestj001,22,BCBSFX,63/G
+play,4,1,fowld001,32,BFBBSFX,T9/L
+play,4,1,zobrb001,22,B*BCFS,K
+play,5,0,bourp001,10,BX,S8/L
+play,5,0,herro001,12,FBSS,K
+play,5,0,galvf001,20,BBX,8/F
+play,5,0,franm004,32,SF*B*BB>B,W.1-2
+play,5,0,joset001,01,CX,54(1)/FO/G
+play,5,1,bryak001,12,CBFFFX,HR/7/F
+play,5,1,solej001,00,,NP
+sub,baila001,"Andrew Bailey",0,8,1
+play,5,1,solej001,22,.CCBBC,K
+play,5,1,szczm001,12,SFBX,9/F
+play,5,1,russa002,22,BFSBFS,K
+play,6,0,ruizc001,11,CBX,9/F
+play,6,0,hernc005,32,BBCBCFX,63/G
+play,6,0,goedt001,32,CSBBBB,W
+play,6,0,baila001,00,,NP
+sub,burre001,"Emmanuel Burriss",0,8,11
+play,6,0,burre001,00,.X,13/G-
+play,6,1,baezj001,00,,NP
+sub,oberb001,"Brett Oberholtzer",0,8,1
+play,6,1,baezj001,10,.BX,S8/L
+play,6,1,rossd001,02,1SFS,K
+play,6,1,lestj001,00,1X,16(1)3/GDP
+play,7,0,bourp001,11,BFX,5/P
+play,7,0,herro001,32,BBFBCFX,D7/L
+play,7,0,galvf001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+com,"56 minute rain delay"
+play,7,0,galvf001,01,.F,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,7,0,galvf001,12,.F.BCX,S9/L.2-3
+play,7,0,franm004,00,X,S5/G-.3-H;1-2
+play,7,0,joset001,32,BBBCCS,K
+play,7,0,ruizc001,22,CBC*BC,K
+play,7,1,fowld001,00,,NP
+sub,murrc002,"Colton Murray",0,4,1
+play,7,1,fowld001,00,,NP
+sub,howar001,"Ryan Howard",0,8,3
+play,7,1,fowld001,22,..CBBSC,K
+play,7,1,zobrb001,11,BCX,43/G
+play,7,1,bryak001,32,CBFBFBFFB,W
+play,7,1,solej001,00,1B,WP/MREV.1-2
+com,"replay,7,solej001,CHN,scotd901,CHI11,,N,M,PHI,A"
+com,"$when Kris Bryant was called safe at 2B, Phillies"
+com,"manager Pete Mackanin challenged the ruling; the"
+com,"call was upheld by replay"
+play,7,1,solej001,32,1B.BBCCC,K
+play,8,0,hernc005,11,SBX,S8/L
+play,8,0,goedt001,12,LBF1F1X,64(1)3/GDP
+play,8,0,howar001,32,FBBFBS,K
+play,8,1,szczm001,11,CBX,S5/G+
+play,8,1,russa002,22,SB1S1BS,K
+play,8,1,baezj001,00,X,8/F
+play,8,1,rossd001,02,1FFX,9/F
+play,9,0,bourp001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,9,0,bourp001,00,,NP
+sub,rizza001,"Anthony Rizzo",1,4,3
+play,9,0,bourp001,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,9,0,bourp001,12,..LS.BFX,9/L
+play,9,0,herro001,00,X,S7/L
+play,9,0,galvf001,31,SBBBX,36(1)1/GDP
+data,er,morga001,6
+data,er,baila001,0
+data,er,oberb001,0
+data,er,murrc002,0
+data,er,lestj001,1
+data,er,strop001,0
+data,er,cahit001,0
+data,er,rondh001,0
+id,CHN201605280
+version,2
+info,visteam,PHI
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/28
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,barrl901
+info,ump1b,barbs901
+info,ump2b,scotd901
+info,ump3b,davib902
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,75
+info,winddir,tocf
+info,windspeed,18
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,138
+info,attendance,41555
+info,wp,hendk001
+info,lp,eickj001
+info,save,
+start,herro001,"Odubel Herrera",0,1,8
+start,galvf001,"Freddy Galvis",0,2,6
+start,franm004,"Maikel Franco",0,3,5
+start,howar001,"Ryan Howard",0,4,3
+start,ruppc001,"Cameron Rupp",0,5,2
+start,hernc005,"Cesar Hernandez",0,6,4
+start,lougd001,"David Lough",0,7,7
+start,eickj001,"Jerad Eickhoff",0,8,1
+start,bourp001,"Peter Bourjos",0,9,9
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,solej001,"Jorge Soler",1,6,7
+start,montm001,"Miguel Montero",1,7,2
+start,russa002,"Addison Russell",1,8,6
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,herro001,11,SBX,S1/BG
+play,1,0,galvf001,02,S>F1,PO1(13)
+play,1,0,galvf001,12,S>F1.BC,K
+play,1,0,franm004,11,BCX,43/G
+play,1,1,fowld001,31,BBBCX,HR/78/F
+play,1,1,heywj001,21,CBBX,D9/F-
+play,1,1,bryak001,01,FX,43/G
+play,1,1,rizza001,10,BX,9/F.2-3
+play,1,1,zobrb001,32,C*BBBFX,D7/L.3-H
+play,1,1,solej001,22,CBBFC,K
+play,2,0,howar001,32,BFBSBFS,K
+play,2,0,ruppc001,02,CCS,K
+play,2,0,hernc005,11,CBX,31/G
+play,2,1,montm001,22,BBFFC,K
+play,2,1,russa002,00,X,S7/L
+play,2,1,hendk001,00,1X,S9/L.1-2
+play,2,1,fowld001,22,BTBFX,8/F
+play,2,1,heywj001,32,CC*BBFB>X,D7/L.2-H;1XH(762)
+play,3,0,lougd001,11,CBX,13/G
+play,3,0,eickj001,21,BBCX,13/G-
+play,3,0,bourp001,02,CCC,K
+play,3,1,bryak001,02,FCS,K23
+play,3,1,rizza001,00,H,HP
+play,3,1,zobrb001,22,1BCC1BX,3/P
+play,3,1,solej001,02,S11F>B,CS2(24)
+play,4,0,herro001,21,BCBX,8/F
+play,4,0,galvf001,02,LCX,S9/L
+play,4,0,franm004,32,CB*BS11FB+1X,7/F
+play,4,0,howar001,21,SBBX,7/F
+play,4,1,solej001,21,BBCX,13/G-
+play,4,1,montm001,32,SFBBBS,K
+play,4,1,russa002,12,CCBFX,63/G
+play,5,0,ruppc001,01,CX,8/F
+play,5,0,hernc005,02,CFC,K
+play,5,0,lougd001,01,CX,S8/G
+play,5,0,eickj001,00,X,64(1)/FO/G
+play,5,1,hendk001,02,CSS,K
+play,5,1,fowld001,32,BSBBCS,K
+play,5,1,heywj001,22,BBFFFFX,3/G
+play,6,0,bourp001,00,X,63/G
+play,6,0,herro001,22,CBBFX,6/P
+play,6,0,galvf001,02,CCH,HP
+play,6,0,franm004,01,FX,3/P3F
+play,6,1,bryak001,20,BBX,S7/G
+play,6,1,rizza001,12,1CBF1S,K
+play,6,1,zobrb001,00,X,S9/L.1-3
+play,6,1,solej001,32,1CB*BS*BFB,W.1-2
+play,6,1,montm001,21,S*BBX,1/G.3-H;2-3;1-2
+play,6,1,russa002,21,CBBX,9/F
+play,7,0,howar001,01,CX,43/G
+play,7,0,ruppc001,12,CCBS,K
+play,7,0,hernc005,11,CBX,D9/L
+play,7,0,lougd001,01,FX,4/P
+play,7,1,hendk001,00,,NP
+sub,baila001,"Andrew Bailey",0,8,1
+play,7,1,hendk001,02,.SCS,K
+play,7,1,fowld001,00,X,53/G
+play,7,1,heywj001,12,CCBFFX,63/G
+play,8,0,baila001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,8,0,baila001,00,,NP
+sub,baezj001,"Javier Baez",1,6,5
+play,8,0,baila001,00,,NP
+sub,blana001,"Andres Blanco",0,8,11
+play,8,0,blana001,12,...CBSX,13/G
+play,8,0,bourp001,11,BFX,63/G
+play,8,0,herro001,01,CX,7/F
+play,8,1,bryak001,00,,NP
+sub,araue001,"Elvis Araujo",0,8,1
+play,8,1,bryak001,11,.CBX,8/F
+play,8,1,rizza001,12,BCCX,8/F
+play,8,1,zobrb001,22,BCBCS,K
+play,9,0,galvf001,00,X,D9/F
+play,9,0,franm004,31,BFBBX,43/G.2-3
+play,9,0,howar001,02,SSFF>S,K23.3-H
+play,9,0,ruppc001,11,FBX,53/G
+data,er,eickj001,4
+data,er,baila001,0
+data,er,araue001,0
+data,er,hendk001,1
+id,CHN201605290
+version,2
+info,visteam,PHI
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/29
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,barbs901
+info,ump1b,scotd901
+info,ump2b,davib902
+info,ump3b,barrl901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,76
+info,winddir,torf
+info,windspeed,20
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,170
+info,attendance,41575
+info,wp,lackj001
+info,lp,velav001
+info,save,
+start,herro001,"Odubel Herrera",0,1,8
+start,galvf001,"Freddy Galvis",0,2,6
+start,blana001,"Andres Blanco",0,3,4
+start,franm004,"Maikel Franco",0,4,5
+start,joset001,"Tommy Joseph",0,5,3
+start,ruppc001,"Cameron Rupp",0,6,2
+start,goedt001,"Tyler Goeddel",0,7,7
+start,velav001,"Vincent Velasquez",0,8,1
+start,bourp001,"Peter Bourjos",0,9,9
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,montm001,"Miguel Montero",1,6,2
+start,russa002,"Addison Russell",1,7,6
+start,szczm001,"Matt Szczur",1,8,7
+start,lackj001,"John Lackey",1,9,1
+play,1,0,herro001,20,BBX,7/F
+play,1,0,galvf001,21,BTBX,31/G-
+play,1,0,blana001,02,CCT,K
+play,1,1,fowld001,32,CCBBBFX,S8/L-
+play,1,1,heywj001,00,1X,S7/L-.1-2
+play,1,1,bryak001,12,CBCS,K
+play,1,1,rizza001,11,BCX,S7/L-.2-H;1-2
+play,1,1,zobrb001,01,CX,46(1)3/GDP
+play,2,0,franm004,12,CBFFX,3/P3F
+play,2,0,joset001,12,CBSX,8/L
+play,2,0,ruppc001,01,FX,9/L
+play,2,1,montm001,20,BBX,HR/9/F
+play,2,1,russa002,02,FSS,K
+play,2,1,szczm001,02,FSFX,2/P2F
+play,2,1,lackj001,22,CBFBS,K
+play,3,0,goedt001,32,CBBFBB,W
+play,3,0,velav001,22,LBSF1BX,9/F
+play,3,0,bourp001,02,1FSS,K
+play,3,0,herro001,12,FFBS,K
+play,3,1,fowld001,00,X,9/L
+play,3,1,heywj001,11,BCX,6/P-
+play,3,1,bryak001,01,SX,S6/G+
+play,3,1,rizza001,31,1BBSBB,W.1-2
+play,3,1,zobrb001,01,CX,HR/9/L.2-H;1-H
+play,3,1,montm001,21,BBCX,43/G
+play,4,0,galvf001,00,X,D8/L+
+play,4,0,blana001,00,X,43/G.2-3
+play,4,0,franm004,32,BBS*BFB,W
+play,4,0,joset001,10,BX,4(1)3/GDP
+play,4,1,russa002,12,FBSS,K
+play,4,1,szczm001,12,FSBFC,K
+play,4,1,lackj001,01,FX,63/G
+play,5,0,ruppc001,12,FCBFX,S7/L
+play,5,0,goedt001,10,BX,54(1)3/GDP
+play,5,0,velav001,00,X,S9/L
+play,5,0,bourp001,12,BCSB,WP.1-2
+play,5,0,bourp001,32,BCSB.*BB,W
+play,5,0,herro001,22,BBSSS,K
+play,5,1,fowld001,31,BCBBB,W
+play,5,1,heywj001,20,11BBX,E6/FO/G.1X3(6545);B-2
+play,5,1,bryak001,31,SBBBX,S8/L.2-H
+play,5,1,rizza001,10,1BX,S1/G.1-2
+play,5,1,zobrb001,22,BCBST,K
+play,5,1,montm001,01,CX,S7/L-.2-H;1-2
+play,5,1,russa002,00,,NP
+sub,oberb001,"Brett Oberholtzer",0,8,1
+play,5,1,russa002,21,.BBSX,64(1)/FO/G
+play,6,0,galvf001,22,CSBBX,43/G
+play,6,0,blana001,01,FX,31/G
+play,6,0,franm004,00,X,63/G
+play,6,1,szczm001,01,CX,8/F
+play,6,1,lackj001,02,FFFC,K
+play,6,1,fowld001,31,SBBB*B,W
+play,6,1,heywj001,32,1CBBBC>F>B,W.1-2
+play,6,1,bryak001,22,BCSBB,WP.2-3;1-2
+play,6,1,bryak001,32,BCSBB.*B,W
+play,6,1,rizza001,22,BFCBX,3/G
+play,7,0,joset001,12,CSBFFS,K
+play,7,0,ruppc001,12,SCBS,K23
+play,7,0,goedt001,10,BX,HR/78/F
+play,7,0,oberb001,00,,NP
+sub,lougd001,"David Lough",0,8,11
+play,7,0,lougd001,32,.BFSBBB,W
+play,7,0,bourp001,01,SX,3/P3F
+play,7,1,zobrb001,00,,NP
+sub,hernd002,"David Hernandez",0,8,1
+play,7,1,zobrb001,22,.CSBBS,K
+play,7,1,montm001,32,CSBBBFFFB,W
+play,7,1,russa002,00,X,S1/G-.1-2
+play,7,1,szczm001,02,FSFX,5(2)3/GDP/MREV
+com,"replay,7,szczm001,CHN,scotd901,CHI11,,Y,M,PHI,C"
+com,"$when Matt Szczur was called safe at 1B, Phillies"
+com,"manager Pete Mackanin challenged the ruling; the"
+com,"call was overturned by replay"
+play,8,0,herro001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,herro001,10,.BX,7/F
+play,8,0,galvf001,31,BFBBX,6/P
+play,8,0,blana001,10,BX,S7/L
+play,8,0,franm004,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,8,0,franm004,00,.B,WP.1-2
+play,8,0,franm004,10,.B.X,13/G
+play,8,1,strop001,00,,NP
+sub,murrc002,"Colton Murray",0,4,1
+play,8,1,strop001,00,,NP
+sub,blana001,"Andres Blanco",0,3,5
+play,8,1,strop001,00,,NP
+sub,hernc005,"Cesar Hernandez",0,8,4
+play,8,1,strop001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,8,1,lastt001,22,....BBSFC,K
+play,8,1,fowld001,22,CBFBFFX,8/L
+play,8,1,heywj001,00,,NP
+sub,nerih001,"Hector Neris",0,4,1
+play,8,1,heywj001,22,.BCBCC,K
+play,9,0,joset001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,9,0,joset001,10,.BX,HR/8/L
+play,9,0,ruppc001,02,CSX,31/G
+play,9,0,goedt001,32,BCBBCX,4/P
+play,9,0,hernc005,12,BSCS,K
+data,er,velav001,7
+data,er,oberb001,0
+data,er,hernd002,0
+data,er,murrc002,0
+data,er,nerih001,0
+data,er,lackj001,1
+data,er,woodt004,0
+data,er,strop001,0
+data,er,grimj002,1
+id,CHN201605300
+version,2
+info,visteam,LAN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/30
+info,number,0
+info,starttime,4:05PM
+info,daynight,day
+info,usedh,false
+info,umphome,emmep901
+info,ump1b,wolfj901
+info,ump2b,johna901
+info,ump3b,lentn901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,speaa701
+info,temp,70
+info,winddir,tolf
+info,windspeed,12
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,160
+info,attendance,41470
+info,wp,woodt004
+info,lp,wooda002
+info,save,rondh001
+start,utlec001,"Chase Utley",0,1,4
+start,seagc001,"Corey Seager",0,2,6
+start,turnj001,"Justin Turner",0,3,5
+start,gonza003,"Adrian Gonzalez",0,4,3
+start,pedej001,"Joc Pederson",0,5,8
+start,grany001,"Yasmani Grandal",0,6,2
+start,puigy001,"Yasiel Puig",0,7,9
+start,crawc002,"Carl Crawford",0,8,7
+start,wooda002,"Alex Wood",0,9,1
+start,zobrb001,"Ben Zobrist",1,1,9
+start,heywj001,"Jason Heyward",1,2,8
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,solej001,"Jorge Soler",1,5,7
+start,russa002,"Addison Russell",1,6,6
+start,baezj001,"Javier Baez",1,7,4
+start,rossd001,"David Ross",1,8,2
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,utlec001,32,BCCBBC,K
+play,1,0,seagc001,12,BCFS,K
+play,1,0,turnj001,32,BFCBBX,S9/F-
+play,1,0,gonza003,30,B1BB+1B,W.1-2
+play,1,0,pedej001,12,BFSFX,4/P3F
+play,1,1,zobrb001,32,CSBBBFB,W
+play,1,1,heywj001,32,1BBCCBX,7/F
+play,1,1,bryak001,12,11CF1BFS,K
+play,1,1,rizza001,11,CBX,43/G
+play,2,0,grany001,11,BCX,7/F-
+play,2,0,puigy001,12,CBSS,K
+play,2,0,crawc002,32,FBBFBFX,13/G
+play,2,1,solej001,02,CCC,K
+play,2,1,russa002,00,X,S9/L
+play,2,1,baezj001,00,X,S3/BG.1-2
+play,2,1,rossd001,22,CBBSX,S7/L.2-3;1-2
+play,2,1,hammj002,12,CSFBC,K
+play,2,1,zobrb001,22,CBBCS,K
+play,3,0,wooda002,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+com,"Cubs pitcher Jason Hammel left the game due to an injured leg"
+play,3,0,wooda002,12,.BCCC,K
+play,3,0,utlec001,02,CFX,8/L
+play,3,0,seagc001,02,SCC,K
+play,3,1,heywj001,12,TBSS,K
+play,3,1,bryak001,00,X,S7/G
+play,3,1,rizza001,01,CX,3/G+.1-2
+play,3,1,solej001,32,*BTBCB*B,W
+play,3,1,russa002,22,BSF*BX,6/L
+play,4,0,turnj001,02,CFX,3/P3F
+play,4,0,gonza003,12,BCFS,K
+play,4,0,pedej001,11,SBX,63/G
+play,4,1,baezj001,10,.BX,7/F
+play,4,1,rossd001,32,CFFBBBB,W
+play,4,1,woodt004,00,X,9/F
+play,4,1,zobrb001,01,C>B,CS2(24)
+play,5,0,grany001,11,BCX,63/G
+play,5,0,puigy001,01,FX,53/G
+play,5,0,crawc002,02,SFX,23/G-
+play,5,1,zobrb001,02,CFFX,S9/L.B-3(E9)
+play,5,1,heywj001,12,BCFX,S3/G-.3-H
+play,5,1,bryak001,02,FFS,K
+play,5,1,rizza001,00,X,D9/L+.1-H
+play,5,1,solej001,00,X,53/G.2-3
+play,5,1,russa002,02,SFT,K
+play,6,0,wooda002,00,,NP
+sub,herne001,"Enrique Hernandez",0,9,11
+play,6,0,herne001,32,.FBBFFBX,9/F
+play,6,0,utlec001,01,CX,8/F
+play,6,0,seagc001,12,FSFFBS,K23
+play,6,1,baezj001,00,,NP
+sub,colel001,"Louis Coleman",0,9,1
+play,6,1,baezj001,10,.BX,63/G
+play,6,1,rossd001,32,BCBBSX,8/L
+play,6,1,woodt004,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,6,1,szczm001,22,.BCFBL,K/BF
+play,7,0,turnj001,00,,NP
+sub,grimj002,"Justin Grimm",1,5,1
+play,7,0,turnj001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,7
+play,7,0,turnj001,01,..CX,6/L
+play,7,0,gonza003,22,BFBSS,K
+play,7,0,pedej001,22,FBFBFX,3/G
+play,7,1,zobrb001,00,,NP
+sub,fienc001,"Casey Fien",0,9,1
+play,7,1,zobrb001,32,.BCBBCX,8/F
+play,7,1,heywj001,11,BSX,8/F
+play,7,1,bryak001,12,FBSS,K
+play,8,0,grany001,00,,NP
+sub,strop001,"Pedro Strop",1,5,1
+play,8,0,grany001,02,.SCC,K
+play,8,0,puigy001,22,FCBBFS,K
+play,8,0,crawc002,00,X,7/F-
+play,8,1,rizza001,00,,NP
+sub,howej003,"J.P. Howell",0,8,1
+play,8,1,rizza001,00,,NP
+sub,kendh001,"Howie Kendrick",0,9,7
+play,8,1,rizza001,00,..H,HP
+play,8,1,strop001,00,,NP
+sub,fedet001,"Tim Federowicz",1,5,11
+play,8,1,fedet001,22,.CS1B*BF1X,64(1)3/GDP
+play,8,1,russa002,20,BBX,S8/L
+play,8,1,baezj001,00,,NP
+sub,baezp001,"Pedro Baez",0,8,1
+play,8,1,baezj001,12,.FF1BFX,4/P
+play,9,0,kendh001,00,,NP
+sub,rondh001,"Hector Rondon",1,5,1
+play,9,0,kendh001,22,.FBSBFS,K
+play,9,0,utlec001,00,X,43/G
+play,9,0,seagc001,22,CBSBFX,43/G
+data,er,wooda002,2
+data,er,colel001,0
+data,er,fienc001,0
+data,er,howej003,0
+data,er,baezp001,0
+data,er,hammj002,0
+data,er,woodt004,0
+data,er,grimj002,0
+data,er,strop001,0
+data,er,rondh001,0
+id,CHN201605310
+version,2
+info,visteam,LAN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/05/31
+info,number,0
+info,starttime,7:32PM
+info,daynight,night
+info,usedh,false
+info,umphome,wolfj901
+info,ump1b,johna901
+info,ump2b,lentn901
+info,ump3b,emmep901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,64
+info,winddir,fromlf
+info,windspeed,2
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,177
+info,attendance,34681
+info,wp,blanj001
+info,lp,richc002
+info,save,
+start,utlec001,"Chase Utley",0,1,4
+start,seagc001,"Corey Seager",0,2,6
+start,gonza003,"Adrian Gonzalez",0,3,3
+start,pedej001,"Joc Pederson",0,4,8
+start,thomt002,"Trayce Thompson",0,5,9
+start,kendh001,"Howie Kendrick",0,6,5
+start,grany001,"Yasmani Grandal",0,7,2
+start,crawc002,"Carl Crawford",0,8,7
+start,kazms001,"Scott Kazmir",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,solej001,"Jorge Soler",1,6,7
+start,russa002,"Addison Russell",1,7,6
+start,montm001,"Miguel Montero",1,8,2
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,utlec001,22,CSBBX,9/F
+play,1,0,seagc001,12,CCBC,K
+play,1,0,gonza003,10,BX,S8/L
+play,1,0,pedej001,22,BFBCFS,K
+play,1,1,fowld001,32,CBBCFBFFB,W
+play,1,1,heywj001,11,C1BX,64(1)/FO/G
+play,1,1,bryak001,02,FSS,K
+play,1,1,rizza001,00,1>B,SB2
+play,1,1,rizza001,11,1>B.FH,HP
+play,1,1,zobrb001,12,CBCFS,K
+play,2,0,thomt002,22,CFBBS,K23
+play,2,0,kendh001,10,BX,63/G
+play,2,0,grany001,12,CSBX,E2/G-
+play,2,0,crawc002,12,BSFB,OA.1-2(E2/TH)
+play,2,0,crawc002,22,BSFB.S,K
+play,2,1,solej001,21,BSBX,8/F
+play,2,1,russa002,12,BCSS,K
+play,2,1,montm001,22,BSBSFFX,4/P
+play,3,0,kazms001,22,BBCSC,K
+play,3,0,utlec001,11,BCX,7/F
+play,3,0,seagc001,10,BX,S9/G
+play,3,0,gonza003,12,CSBX,43/G
+play,3,1,arrij001,22,SCBFBS,K
+play,3,1,fowld001,31,CBBBX,S9/L
+play,3,1,heywj001,10,B11,POCS2(136)
+play,3,1,heywj001,22,B11.FFBX,3/P
+play,4,0,pedej001,21,BCBX,7/F
+play,4,0,thomt002,20,BBX,63/G/MREV
+com,"replay,4,thomt002,LAN,emmep901,CHI11,,Y,M,CHN,C"
+com,"$when Trayce Thompson was called safe at 1B, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was overturned by replay"
+play,4,0,kendh001,32,BFCBBX,63/G
+play,4,1,bryak001,22,BBSFX,9/F
+play,4,1,rizza001,21,BCBX,8/F-
+play,4,1,zobrb001,12,FBCS,K
+play,5,0,grany001,32,BCCBFBB,W
+play,5,0,crawc002,11,FBX,64(1)/FO/G
+play,5,0,kazms001,00,1X,16(1)3/GDP
+play,5,1,solej001,02,SCX,53/G
+play,5,1,russa002,21,CBBX,6/P
+play,5,1,montm001,12,BTCS,K
+play,6,0,utlec001,00,X,13/G-
+play,6,0,seagc001,12,CFBX,43/G
+play,6,0,gonza003,02,SFFS,K
+play,6,1,arrij001,12,BCCS,K
+play,6,1,fowld001,21,CBBX,8/F
+play,6,1,heywj001,12,CSBX,13/G+
+play,7,0,pedej001,12,BSFS,K
+play,7,0,thomt002,12,CCFBX,53/G
+play,7,0,kendh001,31,BBBCB,W
+play,7,0,grany001,12,*BS11F>B,SB2
+play,7,0,grany001,32,*BS11F>B.*BB,W+WP.2-3
+play,7,0,crawc002,30,BB*BB,W.1-2
+play,7,0,kazms001,00,,NP
+sub,turnj001,"Justin Turner",0,9,11
+play,7,0,turnj001,02,.CFC,K
+play,7,1,bryak001,00,,NP
+sub,blanj001,"Joe Blanton",0,9,1
+play,7,1,bryak001,10,.BX,4/P
+play,7,1,rizza001,12,CBCS,K
+play,7,1,zobrb001,32,BBCBCS,K
+play,8,0,utlec001,00,,NP
+sub,richc002,"Clayton Richard",1,9,1
+play,8,0,utlec001,32,.CBBBCFFX,S9/L
+play,8,0,seagc001,11,BF1X,S6/G.1-2
+play,8,0,gonza003,00,X,S7/L.2-H;1-2
+play,8,0,pedej001,00,,NP
+sub,warra001,"Adam Warren",1,9,1
+play,8,0,pedej001,12,.BCFX,9/L.2-3
+play,8,0,thomt002,31,BBFBB,W.1-2
+play,8,0,kendh001,32,FBF*BFF*BX,9/F/SF.3-H
+play,8,0,grany001,31,BFBBX,6/P
+play,8,1,solej001,11,BCX,8/F
+play,8,1,russa002,12,CBSS,K
+play,8,1,montm001,22,BCBTX,3/G
+play,9,0,crawc002,00,X,S9/G
+play,9,0,blanj001,00,,NP
+sub,herne001,"Enrique Hernandez",0,9,11
+play,9,0,herne001,32,.BF1CBB>F>X,S8/L.1-3
+play,9,0,utlec001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,6
+play,9,0,utlec001,00,,NP
+sub,cahit001,"Trevor Cahill",1,7,1
+play,9,0,utlec001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,5
+play,9,0,utlec001,01,...C>C,DI.1-2
+play,9,0,utlec001,12,...C>C.BS,K
+play,9,0,seagc001,22,SS*BBX,HR/9/F.3-H;2-H
+play,9,0,gonza003,22,BSSBX,13/G-
+play,9,0,pedej001,31,BBCBX,7/F
+play,9,1,lastt001,00,,NP
+sub,libea001,"Adam Liberatore",0,8,1
+play,9,1,lastt001,00,,NP
+sub,herne001,"Enrique Hernandez",0,9,7
+play,9,1,lastt001,21,..BBCX,8/F
+play,9,1,fowld001,01,CX,8/F
+play,9,1,heywj001,12,BCFS,K
+data,er,kazms001,0
+data,er,blanj001,0
+data,er,libea001,0
+data,er,arrij001,0
+data,er,richc002,2
+data,er,warra001,2
+data,er,cahit001,1
+id,CHN201606010
+version,2
+info,visteam,LAN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/01
+info,number,0
+info,starttime,7:10PM
+info,daynight,night
+info,usedh,false
+info,umphome,johna901
+info,ump1b,lentn901
+info,ump2b,emmep901
+info,ump3b,wolfj901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,73
+info,winddir,ltor
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,149
+info,attendance,36426
+info,wp,lestj001
+info,lp,bolsm001
+info,save,
+start,herne001,"Enrique Hernandez",0,1,4
+start,turnj001,"Justin Turner",0,2,5
+start,seagc001,"Corey Seager",0,3,6
+start,kendh001,"Howie Kendrick",0,4,3
+start,thomt002,"Trayce Thompson",0,5,9
+start,pedej001,"Joc Pederson",0,6,8
+start,ellia001,"A.J. Ellis",0,7,2
+start,crawc002,"Carl Crawford",0,8,7
+start,bolsm001,"Mike Bolsinger",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,7
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,russa002,"Addison Russell",1,6,6
+start,baezj001,"Javier Baez",1,7,5
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,herne001,10,BX,HR/7/F
+play,1,0,turnj001,02,FFS,K23
+play,1,0,seagc001,32,BBBCCFFX,S39/G
+play,1,0,kendh001,11,FBX,13/G.1-2
+play,1,0,thomt002,32,B+2CBC*BX,53/G
+play,1,1,fowld001,01,CH,HP
+play,1,1,heywj001,30,1BBBB,W.1-2
+play,1,1,bryak001,02,CSS,K
+play,1,1,rizza001,12,CTBX,31/G.2-3;1-2
+play,1,1,zobrb001,02,CCFFS,K
+play,2,0,pedej001,22,CBBFC,K
+play,2,0,ellia001,12,CFBC,K
+play,2,0,crawc002,22,SBSBT,K
+play,2,1,russa002,11,CBX,4/P
+play,2,1,baezj001,22,BBCSH,HP
+play,2,1,rossd001,10,B1>B,SB2
+play,2,1,rossd001,22,B1>B.CSFFC,K
+play,2,1,lestj001,10,BX,13/G-
+play,3,0,bolsm001,22,CBCBS,K
+play,3,0,herne001,10,BX,13/G
+play,3,0,turnj001,00,X,4/P-
+play,3,1,fowld001,32,CBFBBB,W
+play,3,1,heywj001,22,1BBFFX,9/L+
+play,3,1,bryak001,10,1BX,HR/8/F.1-H
+play,3,1,rizza001,22,BBCLX,S7/L
+play,3,1,zobrb001,12,CFBF>B,CS2(26)
+play,3,1,zobrb001,22,CFBF>B.FX,8/L+
+play,4,0,seagc001,22,BFCBS,K
+play,4,0,kendh001,21,BFBX,63/G+
+play,4,0,thomt002,02,CSFX,D8/G
+play,4,0,pedej001,32,CBSBBX,3/G
+play,4,1,russa002,21,BFBX,9/F9LF
+play,4,1,baezj001,00,X,7/F
+play,4,1,rossd001,22,BFSBS,K
+play,5,0,ellia001,10,BX,S7/G+
+play,5,0,crawc002,12,BFFFX,7/L
+play,5,0,bolsm001,00,X,26(1)/FO/BG
+play,5,0,herne001,00,X,64(1)/FO/G
+play,5,1,lestj001,01,CX,3/G-
+play,5,1,fowld001,12,CFFBFS,K
+play,5,1,heywj001,12,SBCC,K
+play,6,0,turnj001,12,BCCX,9/F
+play,6,0,seagc001,12,BFCS,K
+play,6,0,kendh001,20,BBX,9/F
+play,6,1,bryak001,00,,NP
+sub,baezp001,"Pedro Baez",0,9,1
+play,6,1,bryak001,22,.TBSBX,8/F
+play,6,1,rizza001,22,FCBBS,K
+play,6,1,zobrb001,10,BX,53/G
+play,7,0,thomt002,11,CBX,31/G-
+play,7,0,pedej001,01,SX,53/G-
+play,7,0,ellia001,00,X,8/L+
+play,7,1,russa002,21,BSBX,4/L+
+play,7,1,baezj001,32,BFBBFFX,23/G-
+play,7,1,rossd001,12,FBSS,K
+play,8,0,crawc002,32,BBCMBC,K
+play,8,0,baezp001,00,,NP
+sub,puigy001,"Yasiel Puig",0,9,11
+play,8,0,puigy001,21,.BBCX,8/L
+play,8,0,herne001,02,CSS,K23
+play,8,1,lestj001,00,,NP
+sub,fienc001,"Casey Fien",0,9,1
+play,8,1,lestj001,22,.SCFBBS,K
+play,8,1,fowld001,22,SSBBS,K
+play,8,1,heywj001,32,BCSBBFX,S8/G
+play,8,1,bryak001,22,1C1BB1S1S,K
+play,9,0,turnj001,20,BBX,63/G
+play,9,0,seagc001,12,CBFX,63/G+
+play,9,0,kendh001,12,CFBT,K
+data,er,bolsm001,2
+data,er,baezp001,0
+data,er,fienc001,0
+data,er,lestj001,1
+id,CHN201606020
+version,2
+info,visteam,LAN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/02
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,lentn901
+info,ump1b,emmep901
+info,ump2b,wolfj901
+info,ump3b,may-b901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,78
+info,winddir,torf
+info,windspeed,9
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,145
+info,attendance,37422
+info,wp,hendk001
+info,lp,uriaj001
+info,save,
+start,utlec001,"Chase Utley",0,1,4
+start,seagc001,"Corey Seager",0,2,6
+start,turnj001,"Justin Turner",0,3,5
+start,gonza003,"Adrian Gonzalez",0,4,3
+start,pedej001,"Joc Pederson",0,5,8
+start,thomt002,"Trayce Thompson",0,6,9
+start,crawc002,"Carl Crawford",0,7,7
+start,ellia001,"A.J. Ellis",0,8,2
+start,uriaj001,"Julio Urias",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,solej001,"Jorge Soler",1,5,7
+start,russa002,"Addison Russell",1,6,6
+start,baezj001,"Javier Baez",1,7,4
+start,montm001,"Miguel Montero",1,8,2
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,utlec001,01,CX,S8/L
+play,1,0,seagc001,22,BSBS1X,16(1)3/GDP
+play,1,0,turnj001,02,CFS,K
+play,1,1,fowld001,01,CX,S9/L-
+play,1,1,heywj001,22,BF1SBFX,54(1)/FO/G
+play,1,1,bryak001,02,FCX,54(1)3/GDP
+play,2,0,gonza003,10,BX,13/G
+play,2,0,pedej001,22,CSBBX,43/G
+play,2,0,thomt002,11,BCX,7/F
+play,2,1,rizza001,32,CBBFFBFB,W
+play,2,1,solej001,00,X,S4/G-.1-2
+play,2,1,russa002,32,BBFBFS,K
+play,2,1,baezj001,21,BSBX,S8/L-.2-H;1-3(E8);B-2
+play,2,1,montm001,12,CSBX,43/G.3-H(UR);2-3
+play,2,1,hendk001,02,FFC,K
+play,3,0,crawc002,11,CBH,HP
+play,3,0,ellia001,12,C11CB>FFX,7/L
+play,3,0,uriaj001,00,X,24/BG/SH.1-2
+play,3,0,utlec001,32,BBFBSX,9/L
+play,3,1,fowld001,21,BCBX,23/G-
+play,3,1,heywj001,01,CX,S7/G
+play,3,1,bryak001,01,C1X,8/L
+play,3,1,rizza001,02,1CFX,7/F
+play,4,0,seagc001,11,BTX,43/G-
+play,4,0,turnj001,32,CBFFBBB,W
+play,4,0,gonza003,00,X,36(1)3/GDP
+play,4,1,solej001,01,CX,S9/L
+play,4,1,russa002,01,SX,3/L-
+play,4,1,baezj001,01,C1X,HR/7/L.1-H
+play,4,1,montm001,12,SCBC,K
+play,4,1,hendk001,12,CCBX,9/L
+play,5,0,pedej001,02,FCL,K/BF
+play,5,0,thomt002,12,CCBX,HR/78/F
+play,5,0,crawc002,01,CX,4/L-
+play,5,0,ellia001,22,BCBFS,K
+play,5,1,fowld001,32,CBBBFX,63/G
+play,5,1,heywj001,21,CBBX,HR/89/L
+play,5,1,bryak001,00,X,HR/78/F
+play,5,1,rizza001,01,CX,43/G
+play,5,1,solej001,12,FBSS,K
+play,6,0,uriaj001,00,,NP
+sub,herne001,"Enrique Hernandez",0,9,11
+play,6,0,herne001,12,.BCSX,S5/G-
+play,6,0,utlec001,11,FBX,43/G-.1-2
+play,6,0,seagc001,02,FFB,WP.2-3
+play,6,0,seagc001,22,FFB.BX,7/F/SF.3-H
+play,6,0,turnj001,11,BCX,53/G
+play,6,1,russa002,00,,NP
+sub,hatcc002,"Chris Hatcher",0,9,1
+play,6,1,russa002,32,.SSBBBB,W
+play,6,1,baezj001,02,CC1S,K
+play,6,1,montm001,00,X,8/F
+play,6,1,hendk001,22,CSBBFS,K
+play,7,0,gonza003,21,CBBX,43/G
+play,7,0,pedej001,22,CBCBX,43/G
+play,7,0,thomt002,32,BSCBBS,K
+play,7,1,fowld001,22,BBFFC,K
+play,7,1,heywj001,32,CBBBFS,K
+play,7,1,bryak001,12,SSBS,K
+play,8,0,crawc002,00,,NP
+sub,szczm001,"Matt Szczur",1,5,7
+play,8,0,crawc002,10,.BX,3/G
+play,8,0,ellia001,02,CFFS,K23
+play,8,0,hatcc002,00,,NP
+sub,puigy001,"Yasiel Puig",0,9,11
+play,8,0,puigy001,12,.FBFC,K
+play,8,1,rizza001,00,,NP
+sub,howej003,"J.P. Howell",0,9,1
+play,8,1,rizza001,11,.CBX,HR/8/L
+play,8,1,szczm001,00,,NP
+sub,colel001,"Louis Coleman",0,9,1
+play,8,1,szczm001,32,.CBSBBX,S5/G-
+play,8,1,russa002,02,CFS,K
+play,8,1,baezj001,20,BBX,6/P
+play,8,1,montm001,30,BBBB,W.1-2
+play,8,1,hendk001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,8,1,lastt001,32,.CB*BBF>F>S,K
+play,9,0,utlec001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,9,0,utlec001,22,.CBFBX,63/G
+play,9,0,seagc001,32,CSBFBBFFB,W
+play,9,0,turnj001,02,FFFFX,4/L/DP.1X1(43)
+data,er,uriaj001,5
+data,er,hatcc002,0
+data,er,howej003,1
+data,er,colel001,0
+data,er,hendk001,2
+data,er,woodt004,0
+id,CHN201606030
+version,2
+info,visteam,ARI
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/03
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,wendh902
+info,ump1b,barrs901
+info,ump2b,morag901
+info,ump3b,gibsh902
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,72
+info,winddir,unknown
+info,windspeed,9
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,180
+info,attendance,38813
+info,wp,lackj001
+info,lp,brada001
+info,save,
+start,seguj002,"Jean Segura",0,1,4
+start,bourm001,"Michael Bourn",0,2,9
+start,goldp001,"Paul Goldschmidt",0,3,3
+start,lambj001,"Jake Lamb",0,4,5
+start,castw002,"Welington Castillo",0,5,2
+start,owinc001,"Chris Owings",0,6,8
+start,tomay001,"Yasmany Tomas",0,7,7
+start,ahmen001,"Nick Ahmed",0,8,6
+start,brada001,"Archie Bradley",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,7
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,lastt001,"Tommy La Stella",1,6,5
+start,montm001,"Miguel Montero",1,7,2
+start,baezj001,"Javier Baez",1,8,6
+start,lackj001,"John Lackey",1,9,1
+play,1,0,seguj002,02,CFS,K
+play,1,0,bourm001,00,X,5/P
+play,1,0,goldp001,01,CX,7/F
+play,1,1,fowld001,22,BBFFS,K
+play,1,1,heywj001,02,CCFC,K
+play,1,1,bryak001,22,BSCFBFFX,D8/L
+play,1,1,rizza001,22,CS*BBFX,63/G
+play,2,0,lambj001,22,BCCBX,9/L+
+play,2,0,castw002,22,CFBBX,S56/G-
+play,2,0,owinc001,32,CSFBFB*BB,W.1-2
+play,2,0,tomay001,31,CB*BBX,8/F
+play,2,0,ahmen001,12,CSBS,K
+play,2,1,zobrb001,02,CCX,43/G
+play,2,1,lastt001,21,CBBX,D87/L
+play,2,1,montm001,32,*BCBBCB,W
+play,2,1,baezj001,22,CF*BBFS,K
+play,2,1,lackj001,02,FFT,K
+play,3,0,brada001,02,CCC,K
+play,3,0,seguj002,00,X,S8/G.BX2(84)
+play,3,0,bourm001,22,CBCBS,K
+play,3,1,fowld001,32,BCBBSX,3/G
+play,3,1,heywj001,00,X,7/L+
+play,3,1,bryak001,11,FBX,63/G
+play,4,0,goldp001,32,CBBFBX,8/F
+play,4,0,lambj001,11,CBX,S39/G+
+play,4,0,castw002,30,BBBX,S8/F-.1-2
+play,4,0,owinc001,01,FX,64(1)3/GDP
+play,4,1,rizza001,32,BSFFBBB,W
+play,4,1,zobrb001,12,CBCFX,46(1)3/GDP
+play,4,1,lastt001,22,CCFBBS,K
+play,5,0,tomay001,00,X,4/L-
+play,5,0,ahmen001,22,CBSBFC,K
+play,5,0,brada001,12,CSBS,K
+play,5,1,montm001,00,X,31/G
+play,5,1,baezj001,02,CSS,K
+play,5,1,lackj001,12,CFFBS,K
+play,6,0,seguj002,02,CFFS,K
+play,6,0,bourm001,32,CBBFBS,K
+play,6,0,goldp001,00,X,43/G
+play,6,1,fowld001,32,CBSBBFS,K
+play,6,1,heywj001,32,CCBBBX,S8/L
+play,6,1,bryak001,02,1SFC,K
+play,6,1,rizza001,12,F*BF1X,D8/L+.1-H
+play,6,1,zobrb001,30,IIII,IW
+play,6,1,lastt001,32,BBBCS>S,K
+play,7,0,lambj001,00,,NP
+sub,russa002,"Addison Russell",1,6,6
+play,7,0,lambj001,00,,NP
+sub,baezj001,"Javier Baez",1,8,5
+play,7,0,lambj001,12,..FBFX,13/G
+play,7,0,castw002,22,FSBBS,K
+play,7,0,owinc001,32,CBBBFFFFB,W
+play,7,0,tomay001,02,1FSX,S7/G.1-2
+play,7,0,ahmen001,00,,NP
+sub,warra001,"Adam Warren",1,9,1
+play,7,0,ahmen001,00,,NP
+sub,herrc001,"Chris Herrmann",0,8,11
+play,7,0,herrc001,11,..CBX,43/G
+play,7,1,montm001,00,,NP
+sub,bourm001,"Michael Bourn",0,2,8
+play,7,1,montm001,00,,NP
+sub,owinc001,"Chris Owings",0,6,6
+play,7,1,montm001,00,,NP
+sub,herrc001,"Chris Herrmann",0,8,9
+play,7,1,montm001,00,,NP
+sub,barrj002,"Jake Barrett",0,9,1
+play,7,1,montm001,22,....CBFBS,K
+play,7,1,baezj001,02,CSS,K
+play,7,1,warra001,00,,NP
+sub,solej001,"Jorge Soler",1,9,11
+play,7,1,solej001,31,.BBBC*B,W
+play,7,1,fowld001,11,BSX,4/P3F
+play,8,0,barrj002,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,8,0,barrj002,00,,NP
+sub,weekr001,"Rickie Weeks",0,9,11
+play,8,0,weekr001,22,..SBSBC,K
+play,8,0,seguj002,32,BCBBCX,9/F
+play,8,0,bourm001,21,BCBX,7/L+
+play,8,1,heywj001,00,,NP
+sub,curtz001,"Zac Curtis",0,9,1
+play,8,1,heywj001,11,.BCX,3/G-
+play,8,1,bryak001,01,SH,HP
+play,8,1,rizza001,22,CBCBFX,S9/L/MREV.1-3;BX2(946)
+com,"replay,8,rizza001,CHN,wendh902,CHI11,,N,M,CHN,A"
+com,"$when Anthony Rizzo was called out at 2B, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was upheld by replay"
+play,8,1,zobrb001,30,IIII,IW
+play,8,1,russa002,00,,NP
+sub,bracs001,"Silvino Bracho",0,9,1
+play,8,1,russa002,11,.BSX,D7/G+.3-H;1-H
+play,8,1,montm001,30,IIII,IW
+play,8,1,baezj001,02,CCX,D8/L+.2-H;1-H;B-H(UR)(E6/TH)
+play,8,1,strop001,00,,NP
+sub,fedet001,"Tim Federowicz",1,9,11
+play,8,1,fedet001,02,.CSX,E9/F
+play,8,1,fowld001,22,FFB*BH,HP.1-2
+play,8,1,heywj001,12,SFBB,WP.2-3;1-2
+play,8,1,heywj001,22,SFBB.S,K
+play,9,0,goldp001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,9,0,goldp001,02,.SCX,D8/L
+play,9,0,lambj001,22,CSFBBX,63/G.2-3
+play,9,0,castw002,12,CCBC,K
+play,9,0,owinc001,32,B*BCCBC,K
+data,er,brada001,1
+data,er,barrj002,0
+data,er,curtz001,2
+data,er,bracs001,2
+data,er,lackj001,0
+data,er,warra001,0
+data,er,strop001,0
+data,er,grimj002,0
+id,CHN201606040
+version,2
+info,visteam,ARI
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/04
+info,number,0
+info,starttime,1:23PM
+info,daynight,day
+info,usedh,false
+info,umphome,barrs901
+info,ump1b,morag901
+info,ump2b,gibsh902
+info,ump3b,wendh902
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,68
+info,winddir,tolf
+info,windspeed,9
+info,fieldcond,wet
+info,precip,rain
+info,sky,unknown
+info,timeofgame,166
+info,attendance,40415
+info,wp,hammj002
+info,lp,escoe002
+info,save,rondh001
+start,seguj002,"Jean Segura",0,1,4
+start,drurb001,"Brandon Drury",0,2,9
+start,goldp001,"Paul Goldschmidt",0,3,3
+start,lambj001,"Jake Lamb",0,4,5
+start,castw002,"Welington Castillo",0,5,2
+start,owinc001,"Chris Owings",0,6,8
+start,tomay001,"Yasmany Tomas",0,7,7
+start,ahmen001,"Nick Ahmed",0,8,6
+start,escoe002,"Edwin Escobar",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,solej001,"Jorge Soler",1,6,7
+start,russa002,"Addison Russell",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,seguj002,12,BCFX,13/G-
+play,1,0,drurb001,02,CSS,K
+play,1,0,goldp001,32,FFBBBFB,W
+play,1,0,lambj001,10,BX,HR/89/L.1-H
+play,1,0,castw002,22,CBBSS,K
+play,1,1,fowld001,32,BCBFBX,HR/7/F
+play,1,1,heywj001,10,BX,43/G
+play,1,1,bryak001,32,SBBFBX,9/F
+play,1,1,rizza001,31,CBBBX,8/F
+play,2,0,owinc001,01,SX,8/F
+play,2,0,tomay001,12,CSBFS,K
+play,2,0,ahmen001,11,CBX,2/P2F
+play,2,1,zobrb001,00,X,53/G
+play,2,1,solej001,32,CSBBBX,63/G
+play,2,1,russa002,00,X,63/G
+play,3,0,escoe002,02,CFS,K
+play,3,0,seguj002,32,BBSFFFBFFX,8/F
+play,3,0,drurb001,31,BBBC*B,W
+play,3,0,goldp001,32,*BC*BBC>X,13/G-
+play,3,1,rossd001,12,BCFX,7/L
+play,3,1,hammj002,00,X,7/F
+play,3,1,fowld001,22,BFBFX,S7/L
+play,3,1,heywj001,11,BCX,13/G-
+play,4,0,lambj001,22,BBCFFS,K
+play,4,0,castw002,32,BBBCFS,K
+play,4,0,owinc001,02,CSX,3/L
+play,4,1,bryak001,31,BBSBX,9/F
+play,4,1,rizza001,00,X,S7/F-
+play,4,1,zobrb001,32,*BBBCFB,W.1-2
+play,4,1,solej001,20,*BBX,DGR/78/L+.2-H;1-3
+play,4,1,russa002,02,CCS,K
+play,4,1,rossd001,30,IIII,IW
+play,4,1,hammj002,10,BX,S9/G.3-H;2-H;1-3
+play,4,1,fowld001,00,,NP
+sub,delgr001,"Randall Delgado",0,9,1
+play,4,1,fowld001,22,.FBCBS,K
+play,5,0,tomay001,11,CBX,53/G
+play,5,0,ahmen001,10,BX,4/P
+play,5,0,delgr001,01,CX,63/G
+play,5,1,heywj001,30,BBBX,8/F
+play,5,1,bryak001,00,X,2/P2F
+play,5,1,rizza001,31,CBBBX,9/F
+play,6,0,seguj002,11,BCX,9/L
+play,6,0,drurb001,01,FX,53/G
+play,6,0,goldp001,11,CBX,9/F
+play,6,1,zobrb001,22,BCCBX,43/G
+play,6,1,solej001,00,X,3/P2F
+play,6,1,russa002,32,BBFBFFX,S5/G
+play,6,1,rossd001,01,CB,WP.1-2
+play,6,1,rossd001,32,CB.B*BCFX,8/L
+play,7,0,lambj001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,7,0,lambj001,00,,NP
+sub,baezj001,"Javier Baez",1,6,5
+play,7,0,lambj001,11,..CBX,31/G
+play,7,0,castw002,32,BBBCCX,4/P
+play,7,0,owinc001,10,BX,9/F
+play,7,1,hammj002,00,,NP
+sub,collj001,"Josh Collmenter",0,6,1
+play,7,1,hammj002,00,,NP
+sub,bourm001,"Michael Bourn",0,9,8
+play,7,1,hammj002,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,7,1,lastt001,00,...X,31/G
+play,7,1,fowld001,32,CBSBBX,41/G
+play,7,1,heywj001,22,CSBBC,K
+play,8,0,tomay001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,8,0,tomay001,10,.BX,HR/7/L
+play,8,0,ahmen001,00,X,43/G
+play,8,0,bourm001,22,FCBBFS,K
+play,8,0,seguj002,11,BCX,S8/L
+play,8,0,drurb001,01,SX,S7/L.1-2
+play,8,0,goldp001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,8,0,goldp001,30,.BBBB,W.2-3;1-2
+play,8,0,lambj001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,lambj001,00,,NP
+sub,weekr001,"Rickie Weeks",0,4,11
+play,8,0,weekr001,32,..SFF*BBFB>X,4/L
+play,8,1,bryak001,00,,NP
+sub,drurb001,"Brandon Drury",0,2,5
+play,8,1,bryak001,00,,NP
+sub,weekr001,"Rickie Weeks",0,4,7
+play,8,1,bryak001,00,,NP
+sub,hudsd001,"Daniel Hudson",0,6,1
+play,8,1,bryak001,00,,NP
+sub,tomay001,"Yasmany Tomas",0,7,9
+play,8,1,bryak001,32,....BBSFBS,K
+play,8,1,rizza001,22,CBFBFFX,HR/89/L
+play,8,1,zobrb001,31,FBBBB,W
+play,8,1,baezj001,01,1CX,E6/FO/G.1-2
+play,8,1,russa002,32,BSSBBFS,K
+play,8,1,rossd001,32,CBBBS>C,K
+play,9,0,castw002,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,9,0,castw002,00,.X,9/F
+play,9,0,hudsd001,00,,NP
+sub,herrc001,"Chris Herrmann",0,6,11
+play,9,0,herrc001,10,.BX,7/F
+play,9,0,tomay001,22,BFFBX,4/L
+data,er,escoe002,4
+data,er,delgr001,0
+data,er,collj001,0
+data,er,hudsd001,1
+data,er,hammj002,2
+data,er,strop001,1
+data,er,cahit001,0
+data,er,woodt004,0
+data,er,rondh001,0
+id,CHN201606050
+version,2
+info,visteam,ARI
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/05
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,morag901
+info,ump1b,gibsh902
+info,ump2b,wendh902
+info,ump3b,barrs901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,73
+info,winddir,torf
+info,windspeed,15
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,180
+info,attendance,41596
+info,wp,corbp001
+info,lp,arrij001
+info,save,ziegb001
+start,bourm001,"Michael Bourn",0,1,8
+start,gossp001,"Phil Gosselin",0,2,4
+start,goldp001,"Paul Goldschmidt",0,3,3
+start,lambj001,"Jake Lamb",0,4,5
+start,herrc001,"Chris Herrmann",0,5,2
+start,owinc001,"Chris Owings",0,6,6
+start,tomay001,"Yasmany Tomas",0,7,7
+start,drurb001,"Brandon Drury",0,8,9
+start,corbp001,"Patrick Corbin",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,zobrb001,"Ben Zobrist",1,2,4
+start,bryak001,"Kris Bryant",1,3,3
+start,solej001,"Jorge Soler",1,4,7
+start,baezj001,"Javier Baez",1,5,5
+start,russa002,"Addison Russell",1,6,6
+start,szczm001,"Matt Szczur",1,7,9
+start,montm001,"Miguel Montero",1,8,2
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,bourm001,32,CTBBFFFBFS,K
+play,1,0,gossp001,32,BCBFBB,W
+play,1,0,goldp001,12,C1SFBC,K
+play,1,0,lambj001,22,SBBSS,K
+play,1,1,fowld001,00,X,53/G
+play,1,1,zobrb001,32,BBCBFX,53/G
+play,1,1,bryak001,21,CBBX,S6/G-
+play,1,1,solej001,00,H,HP.1-2
+play,1,1,baezj001,01,SX,64(1)/FO/G
+play,2,0,herrc001,21,FBBX,S9/G
+play,2,0,owinc001,12,CTBF11X,S9/L.1-2
+play,2,0,tomay001,10,*BX,D9/L.2-H;1-H
+play,2,0,drurb001,22,BCFBS,K
+play,2,0,corbp001,02,SSC,K
+play,2,0,bourm001,32,CB*BCBS,K
+play,2,1,russa002,32,CSBBBX,53/G-
+play,2,1,szczm001,01,CX,S7/L
+play,2,1,montm001,32,BBFBFX,36(1)/FO/G
+play,2,1,arrij001,10,*BX,D8/F.1-H
+play,2,1,fowld001,22,BCS*BX,53/G
+play,3,0,gossp001,22,CBFBFC,K
+play,3,0,goldp001,11,BCX,63/G
+play,3,0,lambj001,32,CCBBBS,K
+play,3,1,zobrb001,02,CFS,K
+play,3,1,bryak001,22,BBCFT,K
+play,3,1,solej001,00,X,6/P
+play,4,0,herrc001,02,FCS,K
+play,4,0,owinc001,11,CBX,S7/G
+play,4,0,tomay001,12,C1SB111>B,SB2
+play,4,0,tomay001,22,C1SB111>B.S,K
+play,4,0,drurb001,22,*BSS*BC,K
+play,4,1,baezj001,01,CX,53/G
+play,4,1,russa002,12,CFBFC,K
+play,4,1,szczm001,00,X,13/G+
+play,5,0,corbp001,22,BSCFBX,S7/L
+play,5,0,bourm001,00,>M,CS2(26)
+play,5,0,bourm001,02,>M.FX,S4/G-
+play,5,0,gossp001,10,BX,S8/G.1-2
+play,5,0,goldp001,32,BBFBSX,S7/G.2-H;1-2
+play,5,0,lambj001,02,FSS,K
+play,5,0,herrc001,32,SBSBB>X,S3/G-.2XH(3125);1-2
+play,5,1,montm001,12,CSFBFX,S8/L
+play,5,1,arrij001,01,SX,13/BG/SH.1-2
+play,5,1,fowld001,21,CBBX,53/G
+play,5,1,zobrb001,01,FX,53/G
+play,6,0,owinc001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,6,0,owinc001,02,.CFS,K
+play,6,0,tomay001,12,SBSX,23/G-
+play,6,0,drurb001,32,CBFBFB*B,W
+play,6,0,corbp001,12,SBSS,K
+play,6,1,bryak001,12,BCFX,63/G
+play,6,1,solej001,00,X,53/G+
+play,6,1,baezj001,01,CX,HR/9/L
+play,6,1,russa002,21,SBBX,53/G
+play,7,0,bourm001,12,MBCC,K
+play,7,0,gossp001,12,CSBS,K
+play,7,0,goldp001,32,CBBBCF*B,W
+com,"ej,maddj801,M,gibsh902,Checked swing"
+com,"Cubs Manager Joe Maddon ejected by 1B umpire Tripp Gibson"
+com,"arguing a check swing call"
+play,7,0,lambj001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,7,0,lambj001,12,..BSS>B,SB2
+play,7,0,lambj001,22,..BSS>B.X,143/G+
+play,7,1,szczm001,00,,NP
+sub,ahmen001,"Nick Ahmed",0,6,6
+play,7,1,szczm001,02,.FFS,K
+play,7,1,montm001,02,SFX,3/G
+play,7,1,grimj002,00,,NP
+sub,rossd001,"David Ross",1,9,11
+play,7,1,rossd001,32,.FBCBFBT,K
+play,8,0,herrc001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,herrc001,10,.BX,S69/G
+play,8,0,ahmen001,00,X,13/BG/SH.1-2
+play,8,0,tomay001,02,CTS,K
+play,8,0,drurb001,30,IIII,IW
+play,8,0,corbp001,00,,NP
+sub,weekr001,"Rickie Weeks",0,9,11
+play,8,0,weekr001,22,.FFBBX,3/P3F
+play,8,1,fowld001,00,,NP
+sub,clipt001,"Tyler Clippard",0,9,1
+play,8,1,fowld001,10,.BX,7/F
+play,8,1,zobrb001,32,BBCSBFB,W
+play,8,1,bryak001,02,S1CT,K
+play,8,1,solej001,32,FBBSB>X,63/G
+play,9,0,bourm001,22,CCBBFS,K
+play,9,0,gossp001,00,,NP
+sub,warra001,"Adam Warren",1,4,1
+play,9,0,gossp001,00,,NP
+sub,szczm001,"Matt Szczur",1,7,7
+play,9,0,gossp001,00,,NP
+sub,heywj001,"Jason Heyward",1,9,9
+play,9,0,gossp001,00,...X,63/G
+play,9,0,goldp001,31,BBSBB,W
+play,9,0,lambj001,22,CCBBX,9/L
+play,9,1,baezj001,00,,NP
+sub,ziegb001,"Brad Ziegler",0,9,1
+play,9,1,baezj001,00,,NP
+sub,lastt001,"Tommy La Stella",1,5,11
+play,9,1,lastt001,02,..CFX,8/F
+play,9,1,russa002,11,CBX,13/G
+play,9,1,szczm001,00,,NP
+sub,rizza001,"Anthony Rizzo",1,7,11
+play,9,1,rizza001,31,.BFBBB,W
+play,9,1,montm001,01,CX,3/G-
+data,er,corbp001,2
+data,er,clipt001,0
+data,er,ziegb001,0
+data,er,arrij001,3
+data,er,cahit001,0
+data,er,grimj002,0
+data,er,woodt004,0
+data,er,warra001,0
+id,CHN201606170
+version,2
+info,visteam,PIT
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/17
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,cedeg901
+info,ump1b,coope901
+info,ump2b,wolfj901
+info,ump3b,dejer901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,72
+info,winddir,fromcf
+info,windspeed,7
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,198
+info,attendance,41547
+info,wp,arrij001
+info,lp,lirif001
+info,save,
+start,jasoj001,"John Jaso",0,1,3
+start,polag001,"Gregory Polanco",0,2,9
+start,mccua001,"Andrew McCutchen",0,3,8
+start,freed001,"David Freese",0,4,5
+start,joycm001,"Matthew Joyce",0,5,7
+start,harrj002,"Josh Harrison",0,6,4
+start,mercj002,"Jordy Mercer",0,7,6
+start,stewc001,"Chris Stewart",0,8,2
+start,lirif001,"Francisco Liriano",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,szczm001,"Matt Szczur",1,2,7
+start,zobrb001,"Ben Zobrist",1,3,4
+start,rizza001,"Anthony Rizzo",1,4,3
+start,almoa002,"Albert Almora",1,5,9
+start,baezj001,"Javier Baez",1,6,5
+start,russa002,"Addison Russell",1,7,6
+start,montm001,"Miguel Montero",1,8,2
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,jasoj001,32,CBBFFBFC,K
+play,1,0,polag001,12,FFFBFFX,8/L
+play,1,0,mccua001,12,FBCFS,K23
+play,1,1,fowld001,00,X,S5/G
+play,1,1,szczm001,00,X,HR/78/F.1-H
+play,1,1,zobrb001,32,CBFBBX,53/G
+play,1,1,rizza001,12,BCCS,K
+play,1,1,almoa002,11,BSX,S3/G
+play,1,1,baezj001,10,1BB,WP.1-2
+play,1,1,baezj001,31,1BB.FBB,W
+play,1,1,russa002,12,BTCS,K
+play,2,0,freed001,32,SBFBBX,43/G
+play,2,0,joycm001,22,BCBFS,K
+play,2,0,harrj002,12,CBCFS,K
+play,2,1,montm001,10,BX,43/G
+play,2,1,arrij001,12,CBSS,K
+play,2,1,fowld001,01,CX,4/L
+play,3,0,mercj002,12,CBCFX,S8/G
+play,3,0,stewc001,21,BCB>X,S8/L.1-3
+play,3,0,lirif001,12,BFFS,K
+play,3,0,jasoj001,32,*BC1CFBBS,K
+play,3,0,polag001,12,BFST,K
+play,3,1,szczm001,02,CLS,K
+play,3,1,zobrb001,32,CBBCBS,K
+play,3,1,rizza001,11,BCH,HP
+play,3,1,almoa002,12,*BCSFT,K
+play,4,0,mccua001,00,X,53/G
+play,4,0,freed001,11,BSX,43/G
+play,4,0,joycm001,22,BBFSS,K23
+play,4,1,baezj001,32,BCFBBFFX,D7/L+
+play,4,1,russa002,31,BBSBX,53/G
+play,4,1,montm001,00,X,43/G.2-3
+play,4,1,arrij001,31,BBBCB,W
+play,4,1,fowld001,21,BCBB,PB.1-2
+play,4,1,fowld001,31,BCBB.*B,W
+play,4,1,szczm001,00,X,63/G
+play,5,0,harrj002,11,BFX,8/F
+play,5,0,mercj002,22,CSBFFFBS,K
+play,5,0,stewc001,00,X,8/L
+play,5,1,zobrb001,31,BBBCX,9/L
+play,5,1,rizza001,00,H,HP
+play,5,1,almoa002,30,B*BBB,W.1-2
+play,5,1,baezj001,10,BX,8/F
+play,5,1,russa002,32,CSF*BB*B>F>B,W.2-3;1-2
+play,5,1,montm001,02,CCFX,9/L
+play,6,0,lirif001,00,X,7/F
+play,6,0,jasoj001,32,BBCBF*B,W
+play,6,0,polag001,32,BFBBC*B,W.1-2
+play,6,0,mccua001,00,B,WP.2-3;1-2
+play,6,0,mccua001,31,B.BBCB,W
+play,6,0,freed001,32,*BBBCSFS,K
+play,6,0,joycm001,32,CBBBC>C,K
+play,6,1,arrij001,00,,NP
+sub,coghc001,"Chris Coghlan",1,9,11
+play,6,1,coghc001,20,.BBX,D7/G
+play,6,1,fowld001,10,BX,8/F
+play,6,1,szczm001,02,FFB,WP.2-3
+play,6,1,szczm001,12,FFB.X,4/P
+play,6,1,zobrb001,21,BBCX,S8/L.3-H
+play,6,1,rizza001,00,,NP
+sub,luebc001,"Cory Luebke",0,9,1
+play,6,1,rizza001,32,.CB*BF1FB>F>B,W.1-2
+play,6,1,almoa002,31,BBBCX,D7/L.2-H;1-3
+play,6,1,baezj001,30,IIII,IW
+play,6,1,russa002,32,BCBCB>F>F>F>F>F>F>F>B,W.3-H;2-3;1-2
+play,6,1,montm001,00,,NP
+sub,camia001,"Arquimedes Caminero",0,5,1
+play,6,1,montm001,00,,NP
+sub,rodrs002,"Sean Rodriguez",0,9,7
+play,6,1,montm001,02,..FFX,43/G
+play,7,0,harrj002,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,7,0,harrj002,11,.CBX,9/L
+play,7,0,mercj002,20,BBX,63/G
+play,7,0,stewc001,32,CBBBCX,53/G
+play,7,1,cahit001,01,FX,43/G
+play,7,1,fowld001,32,CBBSFBB,W
+play,7,1,szczm001,22,BBCS1X,S8/F.1-2
+play,7,1,zobrb001,12,*BCFX,43/G.2-3;1-2
+play,7,1,rizza001,32,BCBBCB,W
+play,7,1,almoa002,01,SX,S6/G/MREV.3-H;2-3;1X3(64)
+com,"replay,7,almoa002,CHN,cedeg901,CHI11,,N,M,PIT,C"
+com,"$when Anthony Rizzo collided with Josh Harrison at 2B and"
+com,"the two players rolled around to the left of 2B, Rizzo was"
+com,"called out; Pirates manager Clint Hurdle challenged the"
+com,"ruling that the run scored before Rizzo was out; the call"
+com,"was upheld by replay"
+play,8,0,rodrs002,21,BBCX,63/G+
+play,8,0,jasoj001,00,H,HP
+play,8,0,polag001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,polag001,01,.FX,3(B)6(1)/GDP
+play,8,1,baezj001,00,,NP
+sub,scahr001,"Rob Scahill",0,5,1
+play,8,1,baezj001,00,.X,53/G
+play,8,1,russa002,32,BBBCFFFB,W
+play,8,1,montm001,32,SBBFBX,4/L/DP.1X1(43)
+play,9,0,mccua001,00,,NP
+sub,grimj002,"Justin Grimm",1,8,1
+play,9,0,mccua001,00,,NP
+sub,contw001,"Willson Contreras",1,9,2
+play,9,0,mccua001,00,..X,S1/G-
+play,9,0,freed001,22,FS*B*BFFX,7/L-
+play,9,0,scahr001,00,,NP
+sub,kangj001,"Jung Ho Kang",0,5,11
+play,9,0,kangj001,22,.BCBFFS,K
+play,9,0,harrj002,00,>B,DI.1-2
+play,9,0,harrj002,31,>B.FBBB,W
+play,9,0,mercj002,00,B,WP.2-3;1-2
+play,9,0,mercj002,22,B.TFBC,K
+data,er,lirif001,4
+data,er,luebc001,1
+data,er,camia001,1
+data,er,scahr001,0
+data,er,arrij001,0
+data,er,cahit001,0
+data,er,woodt004,0
+data,er,grimj002,0
+id,CHN201606180
+version,2
+info,visteam,PIT
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/18
+info,number,0
+info,starttime,7:17PM
+info,daynight,night
+info,usedh,false
+info,umphome,coope901
+info,ump1b,wolfj901
+info,ump2b,dejer901
+info,ump3b,cedeg901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,73
+info,winddir,fromrf
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,180
+info,attendance,41424
+info,wp,lestj001
+info,lp,niesj001
+info,save,rondh001
+start,mercj002,"Jordy Mercer",0,1,6
+start,harrj002,"Josh Harrison",0,2,4
+start,mccua001,"Andrew McCutchen",0,3,8
+start,kangj001,"Jung Ho Kang",0,4,5
+start,freed001,"David Freese",0,5,3
+start,joycm001,"Matthew Joyce",0,6,7
+start,rodrs002,"Sean Rodriguez",0,7,9
+start,krate001,"Erik Kratz",0,8,2
+start,niesj001,"Jon Niese",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,7
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,baezj001,"Javier Baez",1,6,5
+start,russa002,"Addison Russell",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,mercj002,11,BFX,HR/7/L
+play,1,0,harrj002,00,X,8/F
+play,1,0,mccua001,32,FBBSFBB,W
+play,1,0,kangj001,20,BB>C,SB2
+play,1,0,kangj001,31,BB>C.BB,W
+play,1,0,freed001,21,CBB>B,CS3(25)
+play,1,0,freed001,32,CBB>B.F>B,W.1-2
+play,1,0,joycm001,01,SX,63/G+
+play,1,1,fowld001,32,CBCBBX,53/G
+play,1,1,heywj001,21,BBFX,31/G
+play,1,1,bryak001,00,X,8/F+
+play,2,0,rodrs002,00,,NP
+sub,almoa002,"Albert Almora",1,1,8
+com,"Cubs center fielder Dexter Fowler left the game due to an injured leg"
+play,2,0,rodrs002,02,.FCS,K
+play,2,0,krate001,11,BSX,6/P
+play,2,0,niesj001,22,CCBFBFT,K
+play,2,1,rizza001,02,CCX,HR/89/L
+play,2,1,zobrb001,21,BBFX,9/L
+play,2,1,baezj001,10,BX,D7/G
+play,2,1,russa002,12,CCFBC,K
+play,2,1,rossd001,30,IIII,IW
+play,2,1,lestj001,22,BCFFBFC,K
+play,3,0,mercj002,00,.X,D7/L
+play,3,0,harrj002,02,CFX,63/G
+play,3,0,mccua001,10,*BX,S8/G.2-H
+play,3,0,kangj001,22,BCCBX,64(1)3/GDP
+play,3,1,almoa002,11,BCX,3/G-
+play,3,1,heywj001,20,BBX,23/G-
+play,3,1,bryak001,32,BFBTBB,W
+play,3,1,rizza001,32,BBFCB>F>X,5/L
+play,4,0,freed001,02,FFX,S8/L
+play,4,0,joycm001,32,B*BCBCX,D9/G.1-3
+play,4,0,rodrs002,00,X,S6/G.3-3;2-2
+play,4,0,krate001,12,SBTS,K
+play,4,0,niesj001,22,BCFBS,K
+play,4,0,mercj002,22,FBBFFH,HP.3-H;2-3;1-2
+play,4,0,harrj002,12,FBFS,K
+play,4,1,zobrb001,00,X,S1/BG
+play,4,1,baezj001,20,BBX,64(1)/FO/G
+play,4,1,russa002,00,1,SB2/MREV
+com,"replay,4,russa002,CHN,cedeg901,CHI11,,Y,M,CHN,A"
+com,"$when Javier Baez was called out at 2B, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was overturned by replay"
+play,4,1,russa002,10,1.BB,WP.2-3
+play,4,1,russa002,30,1.BB.BB,W
+play,4,1,rossd001,01,1SX,3/BG/SH.3-H;1-2
+play,4,1,lestj001,12,BFSS,K
+play,5,0,mccua001,01,CX,3/L
+play,5,0,kangj001,02,CSFS,K
+play,5,0,freed001,00,X,S5/G-
+play,5,0,joycm001,32,BBFBS>S,K
+play,5,1,almoa002,00,X,9/F
+play,5,1,heywj001,11,CBX,31/G
+play,5,1,bryak001,01,CX,HR/7/F
+play,5,1,rizza001,02,CFX,D7/L
+play,5,1,zobrb001,31,*BBCBB,W
+play,5,1,baezj001,12,FFF*BS,K23
+play,6,0,rodrs002,22,CFBFBX,53/G
+play,6,0,krate001,00,X,8/F
+play,6,0,niesj001,32,BFFBFBX,31/G
+play,6,1,russa002,12,CBFS,K
+play,6,1,rossd001,32,FBCBBFX,HR/78/F
+play,6,1,lestj001,00,,NP
+sub,hughj001,"Jared Hughes",0,9,1
+play,6,1,lestj001,00,,NP
+sub,coghc001,"Chris Coghlan",1,9,11
+play,6,1,coghc001,00,..X,7/L
+play,6,1,almoa002,11,BSX,63/G
+play,7,0,mercj002,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,7,0,mercj002,02,.CSS,K
+play,7,0,harrj002,02,CSX,53/G
+play,7,0,mccua001,21,CBBX,43/G
+play,7,1,heywj001,12,CBFH,HP
+play,7,1,bryak001,01,1S>X,53/G.1-2
+play,7,1,rizza001,30,IIII,IW
+play,7,1,zobrb001,31,CB*B*BB,W.2-3;1-2
+play,7,1,baezj001,00,,NP
+sub,felin001,"Neftali Feliz",0,9,1
+play,7,1,baezj001,11,.SBX,64(1)3/GDP
+play,8,0,kangj001,32,BCSBBX,S8/G+
+play,8,0,freed001,01,CX,53/G-.1-2
+play,8,0,joycm001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,joycm001,00,,NP
+sub,rogej002,"Jason Rogers",0,6,11
+play,8,0,rogej002,00,,NP
+sub,marts002,"Starling Marte",0,4,12
+play,8,0,rogej002,02,...CCS,K
+play,8,0,rodrs002,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,8,0,rodrs002,01,.CX,9/F
+play,8,1,russa002,00,,NP
+sub,marts002,"Starling Marte",0,4,7
+play,8,1,russa002,00,,NP
+sub,freed001,"David Freese",0,5,5
+play,8,1,russa002,00,,NP
+sub,melam001,"Mark Melancon",0,6,1
+play,8,1,russa002,00,,NP
+sub,jasoj001,"John Jaso",0,9,3
+play,8,1,russa002,02,....SFX,53/G
+play,8,1,rossd001,32,CBCFBFBB,W
+play,8,1,rondh001,12,BMLL,K/BF
+play,8,1,almoa002,00,X,43/G
+play,9,0,krate001,00,X,13/BG
+play,9,0,jasoj001,22,CBCBX,7/F
+play,9,0,mercj002,22,CBBFC,K
+data,er,niesj001,4
+data,er,hughj001,0
+data,er,felin001,0
+data,er,melam001,0
+data,er,lestj001,3
+data,er,strop001,0
+data,er,woodt004,0
+data,er,rondh001,0
+id,CHN201606190
+version,2
+info,visteam,PIT
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/19
+info,number,0
+info,starttime,7:08PM
+info,daynight,night
+info,usedh,false
+info,umphome,wolfj901
+info,ump1b,dejer901
+info,ump2b,cedeg901
+info,ump3b,coope901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,speaa701
+info,temp,87
+info,winddir,tocf
+info,windspeed,11
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,203
+info,attendance,41024
+info,wp,hendk001
+info,lp,tailj001
+info,save,
+start,jasoj001,"John Jaso",0,1,3
+start,polag001,"Gregory Polanco",0,2,9
+start,mccua001,"Andrew McCutchen",0,3,8
+start,marts002,"Starling Marte",0,4,7
+start,kangj001,"Jung Ho Kang",0,5,5
+start,harrj002,"Josh Harrison",0,6,4
+start,mercj002,"Jordy Mercer",0,7,6
+start,stalj001,"Jacob Stallings",0,8,2
+start,tailj001,"Jameson Taillon",0,9,1
+start,coghc001,"Chris Coghlan",1,1,7
+start,heywj001,"Jason Heyward",1,2,8
+start,bryak001,"Kris Bryant",1,3,9
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,montm001,"Miguel Montero",1,6,2
+start,russa002,"Addison Russell",1,7,6
+start,baezj001,"Javier Baez",1,8,5
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,jasoj001,10,BX,13/G-
+play,1,0,polag001,02,CFS,K
+play,1,0,mccua001,22,CCBBS,K
+play,1,1,coghc001,30,BBBB,W
+play,1,1,heywj001,32,C1BBF*BX,S9/G.1-3
+play,1,1,bryak001,12,SB1SFS,K
+play,1,1,rizza001,10,BX,S6/L-.3-H;1-2
+play,1,1,zobrb001,32,CBBCFBX,7/F
+play,1,1,montm001,22,*BFCFFFBFX,5/P
+play,2,0,marts002,01,CX,S8/L
+play,2,0,kangj001,12,C1C1*B1>B,SB2
+play,2,0,kangj001,22,C1C1*B1>B.S,K
+play,2,0,harrj002,22,CBS*BX,S6/G.2-2
+play,2,0,mercj002,02,CFS,K
+play,2,0,stalj001,12,CBSS,K
+play,2,1,russa002,22,BSBFC,K
+play,2,1,baezj001,22,BBFFX,HR/78/F
+play,2,1,hendk001,11,FBX,53/G
+play,2,1,coghc001,10,BX,S8/L+
+play,2,1,heywj001,02,1FCX,6/P
+play,3,0,tailj001,12,CCBS,K
+play,3,0,jasoj001,00,X,13/G-
+play,3,0,polag001,32,CBBSBX,S9/L+
+play,3,0,mccua001,00,>B,SB2
+play,3,0,mccua001,32,>B.CSBBS,K
+play,3,1,bryak001,30,BBBX,HR/7/L+
+play,3,1,rizza001,10,BX,HR/78/F
+play,3,1,zobrb001,31,BBBCX,9/F
+play,3,1,montm001,12,FCBX,S4/G-
+play,3,1,russa002,02,SFC,K
+play,3,1,baezj001,02,CCN,BK.1-2
+play,3,1,baezj001,12,CCN.*BFX,S9/G+.2XH(92)
+play,4,0,marts002,32,CBBCFBC,K
+play,4,0,kangj001,22,BFCFBS,K
+play,4,0,harrj002,11,BFX,HR/8/F
+play,4,0,mercj002,01,CX,S8/F-
+play,4,0,stalj001,00,X,9/F
+play,4,1,hendk001,02,FCC,K
+play,4,1,coghc001,02,FFFFC,K
+play,4,1,heywj001,20,BBX,8/L
+play,5,0,tailj001,00,,NP
+sub,rodrs002,"Sean Rodriguez",0,9,11
+play,5,0,rodrs002,32,.CBBCBC,K
+play,5,0,jasoj001,32,BSBSBX,43/G
+play,5,0,polag001,22,CBBFX,D8/F
+play,5,0,mccua001,02,SCC,K
+play,5,1,bryak001,00,,NP
+sub,schua001,"A.J. Schugel",0,1,1
+play,5,1,bryak001,00,,NP
+sub,rodrs002,"Sean Rodriguez",0,9,3
+play,5,1,bryak001,02,..CFFT,K
+play,5,1,rizza001,01,CX,7/F
+play,5,1,zobrb001,02,TFX,8/L+
+play,6,0,marts002,11,CBX,7/L
+play,6,0,kangj001,00,X,S8/L+
+play,6,0,harrj002,00,X,13/G-.1-2
+play,6,0,mercj002,00,X,E5/G.2-3
+play,6,0,stalj001,32,BBCB>F>F>F>F>T,K
+play,6,1,montm001,02,FSS,K
+play,6,1,russa002,11,SBX,63/G
+play,6,1,baezj001,21,CBBX,S5/G
+play,6,1,hendk001,00,,NP
+sub,contw001,"Willson Contreras",1,9,11
+play,6,1,contw001,00,.11X,HR/8/F.1-H
+play,6,1,coghc001,10,BX,8/L+
+play,7,0,rodrs002,00,,NP
+sub,grimj002,"Justin Grimm",1,1,1
+play,7,0,rodrs002,00,,NP
+sub,heywj001,"Jason Heyward",1,2,9
+play,7,0,rodrs002,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,7,0,rodrs002,00,,NP
+sub,almoa002,"Albert Almora",1,9,8
+play,7,0,rodrs002,12,....BCSX,8/L
+play,7,0,schua001,00,,NP
+sub,joycm001,"Matthew Joyce",0,1,11
+play,7,0,joycm001,00,,NP
+sub,richc002,"Clayton Richard",1,1,1
+play,7,0,joycm001,22,..CBBFX,S7/G
+play,7,0,polag001,31,BBFB*B,W.1-2
+play,7,0,mccua001,00,,NP
+sub,warra001,"Adam Warren",1,1,1
+play,7,0,mccua001,11,.BSX,54(1)/FO/G.2-3
+play,7,0,marts002,22,*BSSBFX,T7/L+.3-H;1-H
+play,7,0,kangj001,10,BX,S5/G-.3-H
+play,7,0,harrj002,22,1F*BBSFFX,64(1)/FO/G
+play,7,1,heywj001,00,,NP
+sub,partc001,"Curtis Partch",0,1,1
+play,7,1,heywj001,12,.CCFBFFX,S8/L
+play,7,1,bryak001,30,BB*BB,W.1-2
+play,7,1,rizza001,02,CCX,S7/G.2-H;1-3
+play,7,1,zobrb001,00,,NP
+sub,rondj001,"Jorge Rondon",0,1,1
+play,7,1,zobrb001,11,.CBX,FC4/G.3-H;1-2
+play,7,1,montm001,02,FFFX,36(1)1/GDP.2-3
+play,7,1,russa002,12,BCFFX,HR/78/L.3-H
+play,7,1,baezj001,12,CBSX,2/P2F
+play,8,0,mercj002,32,CSBFBBFX,7/F
+play,8,0,stalj001,21,CBBX,53/G
+play,8,0,rodrs002,12,BFFS,K
+play,8,1,almoa002,20,BBX,53/G
+play,8,1,warra001,22,SCBBC,K
+play,8,1,heywj001,00,X,S9/G+
+play,8,1,bryak001,22,*BFF*BS,K
+play,9,0,rondj001,00,,NP
+sub,freed001,"David Freese",0,1,11
+play,9,0,freed001,22,.CSBBFX,D9/L+
+play,9,0,polag001,02,CFX,3/G.2-3
+play,9,0,mccua001,30,BBBX,S5/G-.3-H
+play,9,0,marts002,12,CBFX,S9/G.1-2
+play,9,0,kangj001,00,,NP
+sub,strop001,"Pedro Strop",1,1,1
+play,9,0,kangj001,21,.C*BBX,46(1)/FO/G.2-3
+play,9,0,harrj002,00,>B,DI.1-2
+play,9,0,harrj002,22,>B.CBFS,K
+data,er,tailj001,4
+data,er,schua001,2
+data,er,partc001,3
+data,er,rondj001,1
+data,er,hendk001,1
+data,er,grimj002,0
+data,er,richc002,2
+data,er,warra001,2
+data,er,strop001,0
+id,CHN201606200
+version,2
+info,visteam,SLN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/20
+info,number,0
+info,starttime,7:07PM
+info,daynight,night
+info,usedh,false
+info,umphome,hobep901
+info,ump1b,carlm901
+info,ump2b,wolcq901
+info,ump3b,emmep901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,90
+info,winddir,fromcf
+info,windspeed,11
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,180
+info,attendance,41166
+info,wp,garcj004
+info,lp,lackj001
+info,save,roset001
+start,carpm002,"Matt Carpenter",0,1,4
+start,diaza003,"Aledmys Diaz",0,2,6
+start,hollm001,"Matt Holliday",0,3,7
+start,piscs001,"Stephen Piscotty",0,4,9
+start,peraj001,"Jhonny Peralta",0,5,5
+start,moliy001,"Yadier Molina",0,6,2
+start,mossb001,"Brandon Moss",0,7,3
+start,wongk001,"Kolten Wong",0,8,8
+start,garcj004,"Jaime Garcia",0,9,1
+start,zobrb001,"Ben Zobrist",1,1,4
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,7
+start,rizza001,"Anthony Rizzo",1,4,3
+start,contw001,"Willson Contreras",1,5,2
+start,baezj001,"Javier Baez",1,6,5
+start,russa002,"Addison Russell",1,7,6
+start,almoa002,"Albert Almora",1,8,8
+start,lackj001,"John Lackey",1,9,1
+play,1,0,carpm002,22,CBBFFFS,K
+play,1,0,diaza003,22,BTFFFBFX,S6/G/MREV
+com,"replay,1,diaza003,SLN,emmep901,CHI11,,Y,M,SLN,C"
+com,"$when Aledmys Diaz was called out at 2B, Cardinals"
+com,"manager Mike Matheny challenged the ruling; the"
+com,"call was overturned by replay"
+play,1,0,hollm001,22,*BBFFC,K
+play,1,0,piscs001,32,*B*BC*BC>F>B,W.1-2
+play,1,0,peraj001,00,X,9/F
+play,1,1,zobrb001,22,CBBCX,S1/G
+play,1,1,heywj001,11,BCX,13/G-.1-2
+play,1,1,bryak001,10,BX,9/F
+play,1,1,rizza001,30,BBB*B,W
+play,1,1,contw001,00,X,43/G-
+play,2,0,moliy001,01,SX,8/F
+play,2,0,mossb001,02,CFFX,HR/9/F+
+play,2,0,wongk001,00,X,S7/G
+play,2,0,garcj004,00,X,54/BG/SH.1-2
+play,2,0,carpm002,32,BFBBFFB,W
+play,2,0,diaza003,22,BCFBX,S7/L.2-H;1-2
+play,2,0,hollm001,32,CBSBB>F>B,W.2-3;1-2
+play,2,0,piscs001,10,*BX,8/F
+play,2,1,baezj001,12,CCBX,S6/G-
+play,2,1,russa002,00,X,9/F
+play,2,1,almoa002,02,CFS,K
+play,2,1,lackj001,10,BX,8/L
+play,3,0,peraj001,00,X,HR/7/F
+play,3,0,moliy001,11,FBX,53/G
+play,3,0,mossb001,00,X,8/F
+play,3,0,wongk001,21,BBCX,S9/L
+play,3,0,garcj004,32,SFBFFBB>S,K
+play,3,1,zobrb001,01,CX,S6/G
+play,3,1,heywj001,12,BC1FT,K
+play,3,1,bryak001,21,FBBX,D7/L.1-H
+play,3,1,rizza001,02,CCB,WP.2-3
+play,3,1,rizza001,12,CCB.S,K
+play,3,1,contw001,21,CB*BX,S8/G.3-H
+play,3,1,baezj001,11,CBX,9/F
+play,4,0,carpm002,00,X,7/F
+play,4,0,diaza003,21,CBBX,7/F
+play,4,0,hollm001,00,X,63/G
+play,4,1,russa002,02,CCC,K
+play,4,1,almoa002,00,X,53/G
+play,4,1,lackj001,32,BFBCBX,63/G
+play,5,0,piscs001,12,CBCX,S8/L
+play,5,0,peraj001,12,CBFS,K
+play,5,0,moliy001,12,FS*BX,8/F
+play,5,0,mossb001,00,H,HP.1-2
+play,5,0,wongk001,01,CX,6/L
+play,5,1,zobrb001,22,BCFBS,K
+play,5,1,heywj001,01,CX,3/G
+play,5,1,bryak001,12,CBCH,HP
+play,5,1,rizza001,11,BCX,4/P
+play,6,0,garcj004,22,BFCBFFS,K23
+play,6,0,carpm002,02,CCS,K
+play,6,0,diaza003,12,BMCX,7/L+
+play,6,1,contw001,10,BX,9/F
+play,6,1,baezj001,31,BBBCB,W
+play,6,1,russa002,00,X,9/F
+play,6,1,almoa002,01,C1>X,9/F
+play,7,0,hollm001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,7,0,hollm001,32,.BFBBFS,K
+play,7,0,piscs001,12,BCSS,K
+play,7,0,peraj001,22,SBBCX,3/L
+play,7,1,cahit001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,7,1,szczm001,32,.LBFBFBFC,K
+play,7,1,zobrb001,32,BBBCCX,8/F
+play,7,1,heywj001,12,CBCFFX,S1/G-
+play,7,1,bryak001,00,,NP
+sub,oh--s001,"Seung Hwan Oh",0,3,1
+play,7,1,bryak001,00,,NP
+sub,phamt001,"Tommy Pham",0,9,7
+play,7,1,bryak001,32,..B1BSSB>X,9/F
+play,8,0,moliy001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,moliy001,11,.BFX,8/F
+play,8,0,mossb001,22,BTBSFS,K
+play,8,0,wongk001,12,SFBX,5/L
+play,8,1,rizza001,11,BFX,S8/L
+play,8,1,contw001,32,1FBFFBBX,46(1)3/GDP
+play,8,1,baezj001,22,BFFBFS,K
+play,9,0,phamt001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,9,0,phamt001,12,.CBCS,K
+play,9,0,carpm002,32,BBCBC*B,W
+play,9,0,diaza003,21,BFB>B,CS2(24)
+play,9,0,diaza003,32,BFB>B.FB,W
+play,9,0,oh--s001,00,,NP
+sub,adamm002,"Matt Adams",0,3,11
+play,9,0,adamm002,00,,NP
+sub,richc002,"Clayton Richard",1,9,1
+play,9,0,adamm002,00,,NP
+sub,gyorj001,"Jedd Gyorko",0,3,11
+play,9,0,gyorj001,21,...BFBX,D7/L/MREV.1XH(762)
+com,"replay,9,gyorj001,SLN,emmep901,CHI11,,N,M,SLN,A"
+com,"$when Aledmys Diaz was called out at HP, Cardinals"
+com,"manager Mike Matheny challenged the ruling; the"
+com,"call was upheld by replay"
+play,9,1,russa002,00,,NP
+sub,roset001,"Trevor Rosenthal",0,3,1
+play,9,1,russa002,32,.BBFBFS,K
+play,9,1,almoa002,11,FBX,D8/L
+play,9,1,richc002,00,,NP
+sub,coghc001,"Chris Coghlan",1,9,11
+play,9,1,coghc001,00,.H,HP
+play,9,1,zobrb001,00,*B,OA.2X3(25)
+play,9,1,zobrb001,20,*B.BX,S9/G.1-3
+play,9,1,heywj001,10,BX,4/P
+data,er,garcj004,2
+data,er,oh--s001,0
+data,er,roset001,0
+data,er,lackj001,3
+data,er,cahit001,0
+data,er,woodt004,0
+data,er,grimj002,0
+data,er,richc002,0
+id,CHN201606210
+version,2
+info,visteam,SLN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/21
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,carlm901
+info,ump1b,wolcq901
+info,ump2b,emmep901
+info,ump3b,hobep901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,70
+info,winddir,rtol
+info,windspeed,4
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,175
+info,attendance,41616
+info,wp,waina001
+info,lp,hammj002
+info,save,roset001
+start,carpm002,"Matt Carpenter",0,1,4
+start,diaza003,"Aledmys Diaz",0,2,6
+start,hollm001,"Matt Holliday",0,3,7
+start,piscs001,"Stephen Piscotty",0,4,9
+start,peraj001,"Jhonny Peralta",0,5,5
+start,moliy001,"Yadier Molina",0,6,2
+start,mossb001,"Brandon Moss",0,7,3
+start,wongk001,"Kolten Wong",0,8,8
+start,waina001,"Adam Wainwright",0,9,1
+start,coghc001,"Chris Coghlan",1,1,7
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,contw001,"Willson Contreras",1,6,2
+start,russa002,"Addison Russell",1,7,6
+start,almoa002,"Albert Almora",1,8,8
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,carpm002,01,CX,13/G+
+play,1,0,diaza003,12,CFBC,K
+play,1,0,hollm001,01,SX,13/G-
+play,1,1,coghc001,00,X,S7/L
+play,1,1,heywj001,32,SB1BBFFB,W.1-2
+play,1,1,bryak001,01,FX,8/F.2-3
+play,1,1,rizza001,20,BBX,8/F/SF.3-H
+play,1,1,zobrb001,22,CBBCX,63/G-
+play,2,0,piscs001,10,BX,D8/L
+play,2,0,peraj001,32,FSBBFBX,3/P3F
+play,2,0,moliy001,01,CX,31/G.2-3
+play,2,0,mossb001,01,CX,S8/G.3-H
+play,2,0,wongk001,32,BBBCF>B,W.1-2
+play,2,0,waina001,12,FFBX,6/L
+play,2,1,contw001,32,BCBCBB,W
+play,2,1,russa002,22,BBFCFC,K
+play,2,1,almoa002,00,X,7/L
+play,2,1,hammj002,12,BSFS,K
+play,3,0,carpm002,32,BCBCBX,HR/8/F
+play,3,0,diaza003,32,FBCFBFFBX,S7/L
+play,3,0,hollm001,11,*BFX,HR/8/F.1-H
+play,3,0,piscs001,32,BBCBCX,8/F-
+play,3,0,peraj001,22,BTBSC,K
+play,3,0,moliy001,10,BX,9/F
+play,3,1,coghc001,32,SSBBBB,W
+play,3,1,heywj001,10,BX,D8/L.1-H
+play,3,1,bryak001,01,FX,7/L
+play,3,1,rizza001,32,*BBBCCX,31/G.2-3
+play,3,1,zobrb001,02,CFS,K
+play,4,0,mossb001,01,FH,HP
+play,4,0,wongk001,00,X,46(1)3/GDP
+play,4,0,waina001,21,BBCX,53/G
+play,4,1,contw001,12,SSBX,S9/L-
+play,4,1,russa002,00,X,S8/G.1-3
+play,4,1,almoa002,01,FX,4(1)3/GDP.3-H
+play,4,1,hammj002,12,BFTS,K
+play,5,0,carpm002,12,CCBX,7/L
+play,5,0,diaza003,12,CFBX,53/G
+play,5,0,hollm001,00,X,53/G
+play,5,1,coghc001,00,X,2/P2F
+play,5,1,heywj001,01,CX,3/G
+play,5,1,bryak001,32,BBFSBX,53/G
+play,6,0,piscs001,12,BSFFX,S5/G
+play,6,0,peraj001,01,CX,9/L
+play,6,0,moliy001,12,1BF1F1FS,K
+play,6,0,mossb001,00,,NP
+sub,concg001,"Gerardo Concepcion",1,9,1
+play,6,0,mossb001,12,.1SSFF*BS,K
+play,6,1,rizza001,21,BBCX,S9/G
+play,6,1,zobrb001,00,X,46(1)/FO/G
+play,6,1,contw001,01,CX,64(1)3/GDP
+play,7,0,wongk001,32,BBCBFX,6/L+
+play,7,0,waina001,02,FSC,K
+play,7,0,carpm002,21,BBCX,8/L
+play,7,1,russa002,31,SBBBX,D7/L
+play,7,1,almoa002,32,BBS2BFFX,7/F
+play,7,1,concg001,00,,NP
+sub,montm001,"Miguel Montero",1,9,11
+play,7,1,montm001,21,.BBCX,3/G-.2-3
+play,7,1,coghc001,00,,NP
+sub,broxj001,"Jonathan Broxton",0,9,1
+play,7,1,coghc001,30,.BBBB,W
+play,7,1,heywj001,12,CSFBX,3/G
+play,8,0,diaza003,00,,NP
+sub,strop001,"Pedro Strop",1,1,1
+play,8,0,diaza003,00,,NP
+sub,bryak001,"Kris Bryant",1,3,7
+play,8,0,diaza003,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,8,0,diaza003,32,...BSBSBH,HP
+play,8,0,hollm001,02,SFS,K
+play,8,0,piscs001,10,B1X,7/F
+play,8,0,peraj001,12,BCSS,K
+play,8,1,bryak001,00,,NP
+sub,phamt001,"Tommy Pham",0,3,7
+play,8,1,bryak001,00,,NP
+sub,siegk001,"Kevin Siegrist",0,9,1
+play,8,1,bryak001,21,..FBBX,53/G
+play,8,1,rizza001,32,BBBFSB,W
+play,8,1,zobrb001,00,X,64(1)3/GDP
+play,9,0,moliy001,00,,NP
+sub,woodt004,"Travis Wood",1,1,1
+play,9,0,moliy001,10,.BX,4/P
+play,9,0,mossb001,01,FX,4/P
+play,9,0,wongk001,21,BCBX,6/P5F
+play,9,1,contw001,00,,NP
+sub,roset001,"Trevor Rosenthal",0,9,1
+play,9,1,contw001,02,.CST,K
+play,9,1,russa002,02,CSFX,S9/L
+play,9,1,almoa002,22,BSBFS,K
+play,9,1,baezj001,31,BBBSB,W.1-2
+play,9,1,woodt004,00,,NP
+sub,szczm001,"Matt Szczur",1,1,11
+play,9,1,szczm001,10,.BX,6(1)/FO/G
+data,er,waina001,3
+data,er,broxj001,0
+data,er,siegk001,0
+data,er,roset001,0
+data,er,hammj002,4
+data,er,concg001,0
+data,er,strop001,0
+data,er,woodt004,0
+id,CHN201606220
+version,2
+info,visteam,SLN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/06/22
+info,number,0
+info,starttime,1:22PM
+info,daynight,day
+info,usedh,false
+info,umphome,wolcq901
+info,ump1b,emmep901
+info,ump2b,hobep901
+info,ump3b,carlm901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,73
+info,winddir,torf
+info,windspeed,7
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,182
+info,attendance,41058
+info,wp,wachm001
+info,lp,arrij001
+info,save,
+start,carpm002,"Matt Carpenter",0,1,4
+start,diaza003,"Aledmys Diaz",0,2,6
+start,adamm002,"Matt Adams",0,3,3
+start,piscs001,"Stephen Piscotty",0,4,9
+start,peraj001,"Jhonny Peralta",0,5,5
+start,mossb001,"Brandon Moss",0,6,7
+start,moliy001,"Yadier Molina",0,7,2
+start,wongk001,"Kolten Wong",0,8,8
+start,wachm001,"Michael Wacha",0,9,1
+start,coghc001,"Chris Coghlan",1,1,7
+start,heywj001,"Jason Heyward",1,2,9
+start,bryak001,"Kris Bryant",1,3,5
+start,rizza001,"Anthony Rizzo",1,4,3
+start,zobrb001,"Ben Zobrist",1,5,4
+start,montm001,"Miguel Montero",1,6,2
+start,baezj001,"Javier Baez",1,7,6
+start,szczm001,"Matt Szczur",1,8,8
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,carpm002,12,CTBC,K
+play,1,0,diaza003,11,BFX,S8/L
+play,1,0,adamm002,02,STS,K
+play,1,0,piscs001,11,CB>X,8/F
+play,1,1,coghc001,12,CBFX,63/G
+play,1,1,heywj001,12,CSFBFX,43/G
+play,1,1,bryak001,01,CX,63/G
+play,2,0,peraj001,21,BCBX,D7/L+
+play,2,0,mossb001,32,FBBBSB,W
+play,2,0,moliy001,32,BFF*BBC,K
+play,2,0,wongk001,11,FBX,9/F
+play,2,0,wachm001,22,CBSFFBT,K
+play,2,1,rizza001,20,BBX,8/F
+play,2,1,zobrb001,11,CBX,43/G
+play,2,1,montm001,22,CBBFC,K
+play,3,0,carpm002,32,CBBSBX,31/G
+play,3,0,diaza003,32,CBFFBBFFFFFX,9/L
+play,3,0,adamm002,12,CBSS,K
+play,3,1,baezj001,22,FSFBFBFC,K
+play,3,1,szczm001,21,FBBX,8/F
+play,3,1,arrij001,12,CBCS,K
+play,4,0,piscs001,22,FBFBFX,53/G
+play,4,0,peraj001,22,CBBFX,D7/L
+play,4,0,mossb001,32,BBSSBB,W
+play,4,0,moliy001,32,FSBFFB*BS,K
+play,4,0,wongk001,00,X,8/L+
+play,4,1,coghc001,31,CBBBB,W
+play,4,1,heywj001,21,C1B+1BX,7/F/DP.1X1(73)
+play,4,1,bryak001,31,BBBCB,W
+play,4,1,rizza001,12,CBCX,S7/L.1-2
+play,4,1,zobrb001,12,SBCX,43/G
+play,5,0,wachm001,01,CX,63/G
+play,5,0,carpm002,31,CBBBB,W
+play,5,0,diaza003,10,B>X,S9/G.1-3
+play,5,0,adamm002,30,BBB*B,W.1-2
+play,5,0,piscs001,02,CFFX,54(1)/FO/G.3-H;2-H(UR)(E4/TH)(NR)
+play,5,0,peraj001,01,C>X,9/F
+play,5,1,montm001,00,X,6/P
+play,5,1,baezj001,22,CBFBFC,K
+play,5,1,szczm001,32,BBSBSFS,K
+play,6,0,mossb001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,6,0,mossb001,00,.X,D9/G+
+play,6,0,moliy001,00,B,WP.2-3
+play,6,0,moliy001,10,B.X,FC5/G.3-H
+play,6,0,wongk001,00,,NP
+sub,contw001,"Willson Contreras",1,6,2
+com,"Cubs catcher Miguel Montero left the game due to an injured knee"
+play,6,0,wongk001,00,.X,S8/G+.1-2
+play,6,0,wachm001,10,*BX,3/BP
+play,6,0,carpm002,22,CBFBFX,D8/L.2-H;1-H
+play,6,0,diaza003,00,,NP
+sub,edwac001,"Carl Edwards",1,8,1
+play,6,0,diaza003,00,,NP
+sub,almoa002,"Albert Almora",1,9,8
+play,6,0,diaza003,10,..*BX,HR/78/F.2-H
+play,6,0,adamm002,10,BX,S6/L-
+play,6,0,piscs001,01,SX,FC6/G.1-2
+play,6,0,peraj001,11,BFX,9/L
+play,6,0,mossb001,22,BBFFS,K
+play,6,1,almoa002,02,CFFX,8/L
+play,6,1,coghc001,00,X,43/G
+play,6,1,heywj001,02,CFFX,53/G
+play,7,0,moliy001,00,,NP
+sub,bryak001,"Kris Bryant",1,3,3
+play,7,0,moliy001,00,,NP
+sub,russa002,"Addison Russell",1,4,6
+play,7,0,moliy001,00,,NP
+sub,baezj001,"Javier Baez",1,7,5
+play,7,0,moliy001,22,...SBFFBFS,K
+play,7,0,wongk001,12,CSBX,3/G
+play,7,0,wachm001,32,BBSSBFS,K
+play,7,1,bryak001,21,BSBX,3/P3F
+play,7,1,russa002,22,BB.FSX,D7/L
+play,7,1,zobrb001,32,BTBFBX,7/F
+play,7,1,contw001,22,CFB*BFFX,HR/8/L.2-H
+play,7,1,baezj001,00,,NP
+sub,manes001,"Seth Maness",0,9,1
+play,7,1,baezj001,02,.FSX,6/P5F
+play,8,0,carpm002,00,,NP
+sub,patts002,"Spencer Patton",1,8,1
+play,8,0,carpm002,02,.CCC,K
+play,8,0,diaza003,30,BBB*B,W
+play,8,0,adamm002,12,CCBFX,7/L+
+play,8,0,piscs001,31,BBBCX,8/F
+play,8,1,patts002,10,BX,13/G-
+play,8,1,almoa002,32,CBSFBFBB,W
+play,8,1,coghc001,00,,NP
+sub,lyont001,"Tyler Lyons",0,9,1
+play,8,1,coghc001,02,.FCX,46(1)3/GDP
+play,9,0,peraj001,02,CFS,K
+play,9,0,mossb001,12,FCBS,K
+play,9,0,moliy001,11,BFX,8/F
+play,9,1,heywj001,21,CBBX,7/L
+play,9,1,bryak001,00,,NP
+sub,broxj001,"Jonathan Broxton",0,9,1
+play,9,1,bryak001,02,.CSFX,53/G
+play,9,1,russa002,01,SX,8/F
+data,er,wachm001,2
+data,er,manes001,0
+data,er,lyont001,0
+data,er,broxj001,0
+data,er,arrij001,1
+data,er,grimj002,4
+data,er,edwac001,1
+data,er,patts002,0
+id,CHN201607040
+version,2
+info,visteam,CIN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/04
+info,number,0
+info,starttime,1:22PM
+info,daynight,day
+info,usedh,false
+info,umphome,conrc901
+info,ump1b,mealj901
+info,ump2b,barbs901
+info,ump3b,kulpr901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,seipb701
+info,temp,73
+info,winddir,fromrf
+info,windspeed,8
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,181
+info,attendance,41293
+info,wp,hendk001
+info,lp,reedc002
+info,save,
+start,cozaz001,"Zack Cozart",0,1,6
+start,suare001,"Eugenio Suarez",0,2,5
+start,vottj001,"Joey Votto",0,3,3
+start,brucj001,"Jay Bruce",0,4,9
+start,duvaa001,"Adam Duvall",0,5,7
+start,philb001,"Brandon Phillips",0,6,4
+start,hamib001,"Billy Hamilton",0,7,8
+start,barnt001,"Tucker Barnhart",0,8,2
+start,reedc002,"Cody Reed",0,9,1
+start,baezj001,"Javier Baez",1,1,4
+start,bryak001,"Kris Bryant",1,2,7
+start,rizza001,"Anthony Rizzo",1,3,3
+start,contw001,"Willson Contreras",1,4,2
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,candj002,"Jeimer Candelario",1,7,5
+start,hendk001,"Kyle Hendricks",1,8,1
+start,almoa002,"Albert Almora",1,9,8
+play,1,0,cozaz001,21,BCBX,53/G
+play,1,0,suare001,22,SBBFFFX,4/P
+play,1,0,vottj001,32,CCBBBB,W
+play,1,0,brucj001,32,CBFB*B>X,9/F
+play,1,1,baezj001,11,BFX,63/G
+play,1,1,bryak001,32,CBSBFBFB,W
+play,1,1,rizza001,12,BFCS,K
+play,1,1,contw001,12,CBT1H,HP.1-2
+play,1,1,russa002,10,BX,S7/L.2-H;1-2
+play,1,1,heywj001,22,CBBFFX,D7/L+.2-H;1-H
+play,1,1,candj002,30,IIII,IW
+play,1,1,hendk001,22,SBBFS,K
+play,2,0,duvaa001,02,CCS,K
+play,2,0,philb001,32,BFBSBS,K
+play,2,0,hamib001,02,LFX,8/F
+play,2,1,almoa002,11,LBX,53/G
+play,2,1,baezj001,21,BBFX,E4/G
+play,2,1,bryak001,00,X,HR/8/F.1-H(UR)
+play,2,1,rizza001,22,CFBFBX,43/G
+play,2,1,contw001,11,BFX,HR/7/F.B-H(UR)
+play,2,1,russa002,00,X,7/F
+play,3,0,barnt001,01,CX,53/G
+play,3,0,reedc002,12,BCSX,13/G
+play,3,0,cozaz001,12,BCTX,D7/L
+play,3,0,suare001,11,CBX,6/P
+play,3,1,heywj001,00,X,9/F
+play,3,1,candj002,10,BX,53/G
+play,3,1,hendk001,20,BBX,7/F
+play,4,0,vottj001,12,CBSX,S8/L
+play,4,0,brucj001,22,F*BBFX,36(1)/FO/G
+play,4,0,duvaa001,22,SSFBBX,S7/G.1-2
+play,4,0,philb001,12,CBFFFX,54(1)/FO/G.2-3
+play,4,0,hamib001,12,CBCFX,43/G
+play,4,1,almoa002,21,BFBX,43/G
+play,4,1,baezj001,00,X,S9/L
+play,4,1,bryak001,30,1B*BBB,W.1-2
+play,4,1,rizza001,10,BH,HP.2-3;1-2
+play,4,1,contw001,11,C*BX,52(3)/FO/G.2-3;1-2
+play,4,1,russa002,10,BX,E5/G.3-H(NR)(UR);2-H(UR);1-3;B-2(TH)
+play,4,1,heywj001,01,CX,63/G
+play,5,0,barnt001,12,CSBX,43/G
+play,5,0,reedc002,00,,NP
+sub,holtt001,"Tyler Holt",0,9,11
+play,5,0,holtt001,12,.CBCX,7/F
+play,5,0,cozaz001,22,BCBCX,3/L
+play,5,1,candj002,00,,NP
+sub,smitj004,"Josh Smith",0,9,1
+play,5,1,candj002,31,.BBBCB,W
+play,5,1,hendk001,22,BBSCFX,S8/L.1-2
+play,5,1,almoa002,02,CFS,K
+play,5,1,baezj001,12,CSBX,64(1)/FO/G.2-3
+play,5,1,bryak001,00,,NP
+sub,szczm001,"Matt Szczur",1,2,11
+com,"Cubs LF Kris Bryant left the game due to an injured leg"
+play,5,1,szczm001,00,.X,7/F
+play,6,0,suare001,00,,NP
+sub,szczm001,"Matt Szczur",1,2,7
+play,6,0,suare001,12,.SSFFBX,8/F
+play,6,0,vottj001,10,BX,S9/G+
+play,6,0,brucj001,22,*BCBFX,FC4/MREV.1X3(4E5);B-1
+com,"replay,6,vottj001,CIN,mealj901,CHI11,,N,M,CHN,C"
+com,"replay,6,brucj001,CIN,mealj901,CHI11,,N,M,CHN,C"
+com,"$when Joey Votto was called safe at 2B because Addison"
+com,"Russell never touched the bag, Cubs manager Joe Maddon"
+com,"challenged the ruling; the call was upheld by replay;"
+com,"Votto ran to 3B during the attempt at 1B; Maddon also"
+com,"challenged the ruling at 1B on Jay Bruce; that call"
+com,"was also upheld by replay"
+play,6,0,duvaa001,00,,NP
+sub,edwac001,"Carl Edwards",1,8,1
+play,6,0,duvaa001,32,.BFBSBFX,9/F/SF.3-H(UR)
+play,6,0,philb001,12,BCSX,4/P-
+play,6,1,rizza001,12,SFBX,S9/G+
+play,6,1,contw001,32,BBSBFX,9/F-
+play,6,1,russa002,01,SX,HR/7/L.1-H
+play,6,1,heywj001,31,.BBFBB,W
+play,6,1,candj002,32,BBBCFFS,K
+play,6,1,edwac001,00,,NP
+sub,woodt004,"Travis Wood",1,8,11
+play,6,1,woodt004,00,,NP
+sub,woodb004,"Blake Wood",0,6,1
+play,6,1,woodt004,00,,NP
+sub,dejei002,"Ivan De Jesus",0,9,4
+play,6,1,woodt004,11,...FBX,S8/F-.1-2
+play,6,1,almoa002,01,CX,43/G
+play,7,0,hamib001,00,,NP
+sub,woodt004,"Travis Wood",1,8,1
+play,7,0,hamib001,12,.FFFBX,13/G
+play,7,0,barnt001,10,BX,9/L
+play,7,0,dejei002,10,BX,S8/G
+play,7,0,cozaz001,00,X,HR/7/F.1-H
+play,7,0,suare001,32,BBFFBX,HR/8/F
+play,7,0,vottj001,02,FSS,K
+play,7,1,baezj001,12,FFFFBS,K
+play,7,1,szczm001,32,BFFBBFFB,W
+play,7,1,rizza001,32,BBCFBS,K
+play,7,1,contw001,11,CBX,S5/G-.1-2
+play,7,1,russa002,32,BBBCF>X,5/L
+play,8,0,brucj001,00,,NP
+sub,strop001,"Pedro Strop",1,8,1
+play,8,0,brucj001,00,.X,S6/G
+play,8,0,duvaa001,02,CCS,K
+play,8,0,woodb004,00,,NP
+sub,cabrr001,"Ramon Cabrera",0,6,11
+play,8,0,cabrr001,01,.FX,8/L
+play,8,0,hamib001,22,CBBCX,6(1)/FO/G
+play,8,1,heywj001,00,,NP
+sub,cabrr001,"Ramon Cabrera",0,6,2
+play,8,1,heywj001,00,,NP
+sub,ohler001,"Ross Ohlendorf",0,7,1
+play,8,1,heywj001,00,,NP
+sub,peraj003,"Jose Peraza",0,8,8
+play,8,1,heywj001,32,...BBCSFBFX,S6/G/UREV
+com,"replay,8,heywj001,CHN,mealj901,CHI11,,Y,U,,C"
+com,"$when Jason Heyward was called out at 1B, crew chief"
+com,"Jerry Meals requested a review; the call was"
+com,"overturned by replay"
+play,8,1,candj002,11,FBX,9/L
+play,8,1,strop001,00,,NP
+sub,hammj002,"Jason Hammel",1,8,11
+play,8,1,hammj002,22,.SSF*BBX,S1/G.1-2
+play,8,1,almoa002,00,X,2/P2F
+play,8,1,baezj001,12,C*BSFC,K
+play,9,0,peraj003,00,,NP
+sub,rondh001,"Hector Rondon",1,8,1
+play,9,0,peraj003,00,.X,63/G
+play,9,0,dejei002,11,CBX,S9/G
+play,9,0,cozaz001,00,X,64(1)3/GDP
+data,er,reedc002,4
+data,er,smitj004,2
+data,er,woodb004,0
+data,er,ohler001,0
+data,er,hendk001,0
+data,er,edwac001,0
+data,er,woodt004,3
+data,er,strop001,0
+data,er,rondh001,0
+id,CHN201607050
+version,2
+info,visteam,CIN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/05
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,mealj901
+info,ump1b,barbs901
+info,ump2b,kulpr901
+info,ump3b,conrc901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,84
+info,winddir,tocf
+info,windspeed,8
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,188
+info,attendance,41310
+info,wp,finnb001
+info,lp,lackj001
+info,save,
+start,cozaz001,"Zack Cozart",0,1,6
+start,hamib001,"Billy Hamilton",0,2,8
+start,vottj001,"Joey Votto",0,3,3
+start,brucj001,"Jay Bruce",0,4,9
+start,duvaa001,"Adam Duvall",0,5,7
+start,philb001,"Brandon Phillips",0,6,4
+start,suare001,"Eugenio Suarez",0,7,5
+start,cabrr001,"Ramon Cabrera",0,8,2
+start,finnb001,"Brandon Finnegan",0,9,1
+start,zobrb001,"Ben Zobrist",1,1,9
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,contw001,"Willson Contreras",1,4,7
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,8
+start,rossd001,"David Ross",1,7,2
+start,lackj001,"John Lackey",1,8,1
+start,baezj001,"Javier Baez",1,9,4
+play,1,0,cozaz001,00,X,8/F
+play,1,0,hamib001,31,BCBBB,W
+play,1,0,vottj001,12,F>FB1F>B,SB2
+play,1,0,vottj001,32,F>FB1F>B.*BB,W
+play,1,0,brucj001,00,B,PB.2-H(NR);1-3(E2/TH)
+play,1,0,brucj001,30,B.BBB,W
+play,1,0,duvaa001,02,CFFC,K
+play,1,0,philb001,22,FC*BBX,S7/L.3-H(UR);1X3(75)
+play,1,1,zobrb001,00,X,63/G
+play,1,1,bryak001,02,CFS,K
+play,1,1,rizza001,32,FBBFFBS,K
+play,2,0,suare001,12,CCFFBX,S8/G
+play,2,0,cabrr001,01,FX,7/F
+play,2,0,finnb001,00,X,36(1)/FO/BG
+play,2,0,cozaz001,12,TSFBX,HR/78/F.1-H
+play,2,0,hamib001,32,BCBBCX,S8/L
+play,2,0,vottj001,00,>P,SB2
+play,2,0,vottj001,30,>P.BBB,W
+play,2,0,brucj001,12,FBSX,43/G
+play,2,1,contw001,22,BBCFX,D8/F
+play,2,1,russa002,02,CSS,K
+play,2,1,heywj001,21,BFBX,3/P3F
+play,2,1,rossd001,31,BBBCN,OA
+com,"ej,maddj801,M,mealj901,Balls and strikes"
+com,"Cubs Manager Joe Maddon ejected by HP umpire Jerry Meals"
+play,2,1,rossd001,31,BBBC.B,W
+play,2,1,lackj001,00,X,46(1)/FO/G
+play,3,0,duvaa001,00,X,63/G
+play,3,0,philb001,02,CTX,3/G
+play,3,0,suare001,31,BCBBB,W
+play,3,0,cabrr001,11,*BFX,D9/L+.1-H;B-3(E4)
+play,3,0,finnb001,02,FFFS,K
+play,3,1,baezj001,12,CFFBX,HR/78/F
+play,3,1,zobrb001,31,BBBCX,13/G-
+play,3,1,bryak001,12,SFBX,HR/7/L
+play,3,1,rizza001,30,BBBB,W
+play,3,1,contw001,02,CFFFF1X,8/F
+play,3,1,russa002,01,SX,HR/78/L.1-H
+play,3,1,heywj001,31,BBBC*B,W
+play,3,1,rossd001,10,1BX,7/F
+play,4,0,cozaz001,12,CCFBX,D7/L+
+play,4,0,hamib001,00,X,14/BG/SH.2-3
+play,4,0,vottj001,11,CBX,8/F/SF.3-H
+play,4,0,brucj001,11,FBX,3/G-
+play,4,1,lackj001,02,CFC,K
+play,4,1,baezj001,32,BBFBFB,W
+play,4,1,zobrb001,32,1LFF111BBB>X,9/F
+play,4,1,bryak001,20,B*BX,8/F
+play,5,0,duvaa001,12,CCFBFX,4/P
+play,5,0,philb001,10,BX,63/G
+play,5,0,suare001,11,CBX,13/G-
+play,5,1,rizza001,21,BSBX,31/G
+play,5,1,contw001,00,X,63/G
+play,5,1,russa002,20,BBX,HR/78/L
+play,5,1,heywj001,01,CX,43/G
+play,6,0,cabrr001,32,CBSBBC,K
+play,6,0,finnb001,00,,NP
+sub,dejei002,"Ivan De Jesus",0,9,11
+play,6,0,dejei002,12,.FSBS,K
+play,6,0,cozaz001,11,BCX,2/P2F
+play,6,1,rossd001,00,,NP
+sub,igler001,"Raisel Iglesias",0,9,1
+play,6,1,rossd001,00,.X,S5/BG
+play,6,1,lackj001,00,,NP
+sub,candj002,"Jeimer Candelario",1,8,11
+play,6,1,candj002,02,.CFH,HP.1-2
+play,6,1,baezj001,01,M+2X,1/BP
+play,6,1,zobrb001,00,X,7/F
+play,6,1,bryak001,12,BSFS,K
+play,7,0,hamib001,00,,NP
+sub,woodt004,"Travis Wood",1,8,1
+play,7,0,hamib001,12,.FFBX,D49/L-
+play,7,0,vottj001,11,FB>S,SB3
+play,7,0,vottj001,22,FB>S.BX,D7/L.3-H
+play,7,0,brucj001,00,X,5/P
+play,7,0,duvaa001,31,CBBBX,63/G+
+play,7,0,philb001,11,BCX,8/F
+play,7,1,rizza001,32,BBBCFX,S9/L
+play,7,1,contw001,12,BFFS,K
+play,7,1,russa002,00,X,7/L
+play,7,1,heywj001,30,1BBB*B,W.1-2
+play,7,1,rossd001,00,,NP
+sub,montm001,"Miguel Montero",1,7,11
+play,7,1,montm001,01,.FX,5/P
+play,8,0,suare001,00,,NP
+sub,montm001,"Miguel Montero",1,7,2
+play,8,0,suare001,00,,NP
+sub,peraj002,"Joel Peralta",1,8,1
+play,8,0,suare001,32,..BBBFFFX,8/F
+play,8,0,cabrr001,02,CSFS,K
+play,8,0,igler001,12,BCFX,S9/L
+play,8,0,cozaz001,02,CSFX,9/L
+play,8,1,peraj002,00,,NP
+sub,szczm001,"Matt Szczur",1,8,11
+play,8,1,szczm001,32,.BSBLBX,53/G
+play,8,1,baezj001,22,CSBBS,K
+play,8,1,zobrb001,22,CBSBX,8/F
+play,9,0,hamib001,00,,NP
+sub,strop001,"Pedro Strop",1,8,1
+play,9,0,hamib001,21,.BBFX,1/BP
+play,9,0,vottj001,32,BCSBBB,W
+play,9,0,brucj001,11,BCX,HR/7/F.1-H
+play,9,0,duvaa001,32,SFBBBB,W
+play,9,0,philb001,02,CFS,K
+play,9,0,suare001,01,CX,63/G
+play,9,1,bryak001,00,,NP
+sub,cingt001,"Tony Cingrani",0,9,1
+play,9,1,bryak001,21,.BBCX,53/G
+play,9,1,rizza001,31,BCBBX,8/F
+play,9,1,contw001,32,BBCFFBFX,53/G
+data,er,finnb001,5
+data,er,igler001,0
+data,er,cingt001,0
+data,er,lackj001,5
+data,er,woodt004,1
+data,er,peraj002,0
+data,er,strop001,2
+id,CHN201607060
+version,2
+info,visteam,CIN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/06
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,barbs901
+info,ump1b,kulpr901
+info,ump2b,conrc901
+info,ump3b,mealj901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,85
+info,winddir,torf
+info,windspeed,7
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,176
+info,attendance,41262
+info,wp,desca001
+info,lp,cahit001
+info,save,cingt001
+start,cozaz001,"Zack Cozart",0,1,6
+start,hamib001,"Billy Hamilton",0,2,8
+start,vottj001,"Joey Votto",0,3,3
+start,duvaa001,"Adam Duvall",0,4,9
+start,suare001,"Eugenio Suarez",0,5,5
+start,philb001,"Brandon Phillips",0,6,4
+start,peraj003,"Jose Peraza",0,7,7
+start,barnt001,"Tucker Barnhart",0,8,2
+start,desca001,"Anthony DeSclafani",0,9,1
+start,zobrb001,"Ben Zobrist",1,1,4
+start,bryak001,"Kris Bryant",1,2,9
+start,rizza001,"Anthony Rizzo",1,3,3
+start,contw001,"Willson Contreras",1,4,7
+start,lastt001,"Tommy La Stella",1,5,5
+start,heywj001,"Jason Heyward",1,6,8
+start,russa002,"Addison Russell",1,7,6
+start,montm001,"Miguel Montero",1,8,2
+start,warra001,"Adam Warren",1,9,1
+play,1,0,cozaz001,32,CFFBBFFBFX,HR/8/L
+play,1,0,hamib001,00,X,63/G
+play,1,0,vottj001,02,CSX,43/G-
+play,1,0,duvaa001,32,BSBCBS,K
+play,1,1,zobrb001,02,CCFX,4/L+
+play,1,1,bryak001,21,FBBX,53/G
+play,1,1,rizza001,20,BBX,S9/L+
+play,1,1,contw001,12,BFSS,K
+play,2,0,suare001,22,BSBCFFFFX,8/F
+play,2,0,philb001,12,FBSX,S9/L
+play,2,0,peraj003,01,C>S,SB2
+play,2,0,peraj003,12,C>S.BFX,S8/F-.2-3
+play,2,0,barnt001,10,*B>S,SB2
+play,2,0,barnt001,12,*B>S.CFS,K
+play,2,0,desca001,12,SSFBX,53/G
+play,2,1,lastt001,32,CBFBBFX,S94/F-
+play,2,1,heywj001,20,B11BX,9/F
+play,2,1,russa002,20,*BBX,D7/L.1-H
+play,2,1,montm001,00,X,S49/G.2-H
+play,2,1,warra001,00,X,34/BG/SH.1-2
+play,2,1,zobrb001,11,BCX,3/G
+play,3,0,cozaz001,32,BFBBCFS,K
+play,3,0,hamib001,22,CCBFFBX,8/F
+play,3,0,vottj001,32,BCBFBT,K
+play,3,1,bryak001,21,BBCX,8/F
+play,3,1,rizza001,32,BBFCFFFBFS,K
+play,3,1,contw001,12,SBSX,S5/G-
+play,3,1,lastt001,21,1CBBX,7/F
+play,4,0,duvaa001,22,CBTBX,8/F
+play,4,0,suare001,22,BFFBS,K
+play,4,0,philb001,00,X,8/F
+play,4,1,heywj001,10,BX,S6/G
+play,4,1,russa002,02,1SLT,K
+play,4,1,montm001,00,1X,16(1)3/GDP
+play,5,0,peraj003,12,CBTFFFX,6/P
+play,5,0,barnt001,01,SX,9/L
+play,5,0,desca001,22,BBCSS,K
+play,5,1,warra001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,5,1,szczm001,00,.X,6/P-
+play,5,1,zobrb001,01,CX,HR/9/F
+play,5,1,bryak001,31,BSBBX,S7/L
+play,5,1,rizza001,02,S1FS,K
+play,5,1,contw001,22,C*BBS+11>S,K
+play,6,0,cozaz001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,6,0,cozaz001,32,.BCBFFBS,K
+play,6,0,hamib001,12,FSBS,K
+play,6,0,vottj001,31,BCBBB,W
+play,6,0,duvaa001,02,CSS,K
+play,6,1,lastt001,22,CBCFBS,K
+play,6,1,heywj001,22,CBCBX,8/L+
+play,6,1,russa002,21,BBSX,53/G
+play,7,0,suare001,11,BCX,9/L
+play,7,0,philb001,11,CBX,S8/G
+play,7,0,peraj003,00,X,S9/L.1-3
+play,7,0,barnt001,00,*B,SB2
+play,7,0,barnt001,22,*B.TBSFX,HR/8/F.3-H;2-H
+play,7,0,desca001,00,,NP
+sub,holtt001,"Tyler Holt",0,9,11
+play,7,0,holtt001,22,.CBCBS,K23
+play,7,0,cozaz001,32,BBCBCX,S8/G
+play,7,0,hamib001,21,F11BB>S,SB2
+play,7,0,hamib001,22,F11BB>S.FC,K
+play,7,1,montm001,00,,NP
+sub,lorem002,"Michael Lorenzen",0,9,1
+play,7,1,montm001,31,.BBBCX,1/L+
+play,7,1,cahit001,00,,NP
+sub,candj002,"Jeimer Candelario",1,9,11
+play,7,1,candj002,21,.BCBX,63/G+
+play,7,1,zobrb001,32,BBBCFFB,W
+play,7,1,bryak001,32,BBBCS>C,K
+play,8,0,vottj001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,8,0,vottj001,32,.BFBBFX,6/P-
+play,8,0,duvaa001,30,BBB*B,W
+play,8,0,suare001,22,CSBF>F*B>X,8/F
+play,8,0,philb001,02,1FCX,S68/G.1-3
+play,8,0,peraj003,00,B,WP.3-H(NR);1-2
+play,8,0,peraj003,10,B.X,8/F-
+play,8,1,rizza001,32,CBBFBB,W
+play,8,1,contw001,12,CBFS,K
+play,8,1,lastt001,10,BX,3(B)6(1)/GDP
+play,9,0,barnt001,00,,NP
+sub,grimj002,"Justin Grimm",1,5,1
+play,9,0,barnt001,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,9,0,barnt001,12,..CSFBX,43/G
+play,9,0,lorem002,00,,NP
+sub,brucj001,"Jay Bruce",0,9,11
+play,9,0,brucj001,32,.BCSBBFB,W
+play,9,0,cozaz001,11,CB>X,8/F
+play,9,0,hamib001,20,BB>C,CS2(26)/MREV
+com,"replay,9,hamib001,CIN,mealj901,CHI11,,N,M,CIN,A"
+com,"$when Jay Bruce was called out at 2B, Reds"
+com,"manager Bryan Price challenged the ruling;"
+com,"the call was upheld by replay"
+play,9,1,heywj001,00,,NP
+sub,cingt001,"Tony Cingrani",0,9,1
+play,9,1,heywj001,11,.BCX,6/P
+play,9,1,russa002,02,CTS,K
+play,9,1,montm001,00,,NP
+sub,almoa002,"Albert Almora",1,8,11
+play,9,1,almoa002,32,.BBCBFX,53/G
+data,er,desca001,3
+data,er,lorem002,0
+data,er,cingt001,0
+data,er,warra001,1
+data,er,cahit001,3
+data,er,edwac001,1
+data,er,grimj002,0
+id,CHN201607070
+version,2
+info,visteam,ATL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/07
+info,number,0
+info,starttime,8:40PM
+info,daynight,night
+info,usedh,false
+info,umphome,blakr901
+info,ump1b,everm901
+info,ump2b,bakej902
+info,ump3b,timmt901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,72
+info,winddir,tocf
+info,windspeed,3
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,234
+info,attendance,41480
+info,wp,alvad001
+info,lp,patts002
+info,save,cabrm003
+start,petej002,"Jace Peterson",0,1,4
+start,beckg001,"Gordon Beckham",0,2,6
+start,freef001,"Freddie Freeman",0,3,3
+start,markn001,"Nick Markakis",0,4,9
+start,garca004,"Adonis Garcia",0,5,5
+start,franj004,"Jeff Francoeur",0,6,7
+start,flowt001,"Tyler Flowers",0,7,2
+start,incie001,"Ender Inciarte",0,8,8
+start,harrl002,"Lucas Harrell",0,9,1
+start,lastt001,"Tommy La Stella",1,1,5
+start,bryak001,"Kris Bryant",1,2,7
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,9
+start,contw001,"Willson Contreras",1,5,2
+start,heywj001,"Jason Heyward",1,6,8
+start,russa002,"Addison Russell",1,7,6
+start,hammj002,"Jason Hammel",1,8,1
+start,baezj001,"Javier Baez",1,9,4
+play,1,0,petej002,11,BFX,S7/L
+play,1,0,beckg001,22,BCFB1>X,13/G.1-2
+play,1,0,freef001,22,SBSBS,K
+play,1,0,markn001,01,CX,HR/9/F.2-H
+play,1,0,garca004,22,CBFFBS,K
+play,1,1,lastt001,12,CSBX,2/P
+play,1,1,bryak001,22,SBBCS,K
+play,1,1,rizza001,20,BBX,53/G
+play,2,0,franj004,11,BCX,D9/L+
+play,2,0,flowt001,02,CFS,K
+play,2,0,incie001,02,FFS,K+PB.2-3;B-1
+play,2,0,harrl002,00,1X,FC1/BG.3XH(12);1-2
+play,2,0,petej002,22,CSFB*BX,64(1)/FO/G
+play,2,1,zobrb001,22,BCCBX,31/G
+play,2,1,contw001,11,CBX,13/G
+play,2,1,heywj001,10,BX,8/F
+play,3,0,beckg001,22,BCFFBS,K23
+play,3,0,freef001,11,FBX,13/G-
+play,3,0,markn001,11,CBX,63/G+
+play,3,1,russa002,12,CSBX,43/G
+play,3,1,hammj002,12,CBCS,K
+play,3,1,baezj001,00,X,S8/L+
+play,3,1,lastt001,10,B1X,9/F
+play,4,0,garca004,22,CBBSFX,63/G
+play,4,0,franj004,11,BFX,53/G
+play,4,0,flowt001,12,BSFX,53/G
+play,4,1,bryak001,32,BBCBFFH,HP
+play,4,1,rizza001,00,X,S9/G.1-2
+play,4,1,zobrb001,11,BCX,8/L/DP.2X2(84)
+play,4,1,contw001,22,CBBSX,64(1)/FO/G
+play,5,0,incie001,02,CFX,8/F
+play,5,0,harrl002,22,BCBSC,K
+play,5,0,petej002,32,BBBCSX,63/G
+play,5,1,heywj001,20,BBX,S8/G+
+play,5,1,russa002,32,B1FB1CBF>B,W.1-2
+play,5,1,hammj002,12,L>LFBS,K
+play,5,1,baezj001,31,BB*BCX,4(1)/FO/G.2-3
+play,5,1,lastt001,12,SBF>B,SB2
+play,5,1,lastt001,32,SBF>B.FBS,K
+play,6,0,beckg001,30,BBBB,W
+play,6,0,freef001,00,,NP
+sub,woodt004,"Travis Wood",1,8,1
+play,6,0,freef001,31,.BBBFX,7/F
+play,6,0,markn001,12,B1CFC,K
+play,6,0,garca004,00,,NP
+sub,hendk001,"Kyle Hendricks",1,1,1
+play,6,0,garca004,00,,NP
+sub,candj002,"Jeimer Candelario",1,8,5
+play,6,0,garca004,22,..11BBFSFX,4/P
+play,6,1,bryak001,30,BBB*B,W
+play,6,1,rizza001,00,X,8/F
+play,6,1,zobrb001,32,CBBBF>X,46(1)3/GDP
+play,7,0,franj004,32,FCFBBB*B,W
+play,7,0,flowt001,32,BBCSB>X,7/F+
+play,7,0,incie001,00,1X,7/F
+play,7,0,harrl002,01,FX,31/G
+play,7,1,contw001,32,CBBBCFX,S7/L
+play,7,1,heywj001,00,X,8/F
+play,7,1,russa002,12,BSFX,8/F
+play,7,1,candj002,12,BFCFT,K
+play,8,0,petej002,32,FBBFBX,7/F
+play,8,0,beckg001,12,CBCS,K
+play,8,0,freef001,00,,NP
+sub,grimj002,"Justin Grimm",1,1,1
+play,8,0,freef001,01,.SX,7/F
+play,8,1,baezj001,01,CX,9/F
+play,8,1,grimj002,00,,NP
+sub,almoa002,"Albert Almora",1,1,11
+play,8,1,almoa002,00,.X,63/G
+play,8,1,bryak001,12,CSBFFH,HP
+play,8,1,rizza001,00,,NP
+sub,cervh001,"Hunter Cervenka",0,9,1
+play,8,1,rizza001,30,.*BB*BH,HP.1-2
+play,8,1,zobrb001,12,TS*BFX,D9/G.2-H;1-3
+play,8,1,contw001,00,,NP
+sub,johnj010,"Jim Johnson",0,9,1
+play,8,1,contw001,10,.BX,T8/L.3-H;2-H
+play,8,1,heywj001,32,BFBCBFB,W
+play,8,1,russa002,11,BS>X,7/F
+play,9,0,markn001,00,,NP
+sub,almoa002,"Albert Almora",1,1,8
+play,9,0,markn001,00,,NP
+sub,rondh001,"Hector Rondon",1,2,1
+play,9,0,markn001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,9,0,markn001,00,,NP
+sub,heywj001,"Jason Heyward",1,6,9
+play,9,0,markn001,32,....BSFBBX,HR/89/L
+play,9,0,garca004,22,CSBBS,K
+play,9,0,franj004,32,BCBSB*B,W
+play,9,0,flowt001,22,BCBFS,K
+play,9,0,incie001,02,1SF>B,SB2
+play,9,0,incie001,32,1SF>B.BF*BS,K
+play,9,1,candj002,02,FFX,13/G-
+play,9,1,baezj001,12,BFCX,6/P
+play,9,1,almoa002,12,CBFC,K
+play,10,0,johnj010,00,,NP
+sub,patts002,"Spencer Patton",1,1,1
+play,10,0,johnj010,00,,NP
+sub,szczm001,"Matt Szczur",1,2,8
+play,10,0,johnj010,00,,NP
+sub,aybae001,"Erick Aybar",0,9,11
+play,10,0,aybae001,02,...FFFFS,K
+play,10,0,petej002,01,CX,3/G
+play,10,0,beckg001,12,CBSC,K
+play,10,1,szczm001,00,,NP
+sub,alvad001,"Dario Alvarez",0,2,1
+play,10,1,szczm001,00,,NP
+sub,aybae001,"Erick Aybar",0,9,6
+play,10,1,szczm001,32,..BFCBFFBC,K
+play,10,1,rizza001,12,BCCFS,K
+play,10,1,zobrb001,22,BCFFBFS,K
+play,11,0,freef001,31,BBCBB,W
+play,11,0,markn001,22,BBCC1>FS,K
+play,11,0,garca004,12,1BCF11FX,S4/G.1-2
+play,11,0,franj004,01,SX,9/L
+play,11,0,flowt001,20,BBX,S9/G+.2-H;1-3;B-2(TH)
+play,11,0,incie001,22,BCBFC,K
+play,11,1,contw001,11,BSX,S8/G+
+play,11,1,heywj001,11,BCX,S9/G.1-2
+play,11,1,russa002,00,,NP
+sub,darnc001,"Chase d'Arnaud",0,2,7
+play,11,1,russa002,00,,NP
+sub,cabrm003,"Mauricio Cabrera",0,6,1
+play,11,1,russa002,11,..BSX,64(1)3/GDP.2-3
+play,11,1,candj002,21,BFBX,8/F
+data,er,harrl002,1
+data,er,cervh001,2
+data,er,johnj010,0
+data,er,alvad001,0
+data,er,cabrm003,0
+data,er,hammj002,2
+data,er,woodt004,0
+data,er,hendk001,0
+data,er,grimj002,0
+data,er,rondh001,1
+data,er,patts002,1
+id,CHN201607150
+version,2
+info,visteam,TEX
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/15
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,diazl901
+info,ump1b,tumpj901
+info,ump2b,blasc901
+info,ump3b,nelsj901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,71
+info,winddir,fromlf
+info,windspeed,10
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,164
+info,attendance,41482
+info,wp,hendk001
+info,lp,perem004
+info,save,
+start,odorr001,"Rougned Odor",0,1,4
+start,desmi001,"Ian Desmond",0,2,8
+start,mazan001,"Nomar Mazara",0,3,9
+start,belta001,"Adrian Beltre",0,4,5
+start,fielp001,"Prince Fielder",0,5,3
+start,rua-r001,"Ryan Rua",0,6,7
+start,andre001,"Elvis Andrus",0,7,6
+start,chirr001,"Robinson Chirinos",0,8,2
+start,perem004,"Martin Perez",0,9,1
+start,zobrb001,"Ben Zobrist",1,1,7
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,contw001,"Willson Contreras",1,4,2
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,baezj001,"Javier Baez",1,7,4
+start,almoa002,"Albert Almora",1,8,8
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,odorr001,01,CX,S7/G
+play,1,0,desmi001,11,BCB,PB.1-2
+play,1,0,desmi001,32,BCB.S*BX,43/G.2-3
+play,1,0,mazan001,22,CB*BSS,K
+play,1,0,belta001,32,CBFB*BFB,W
+play,1,0,fielp001,00,X,43/G
+play,1,1,zobrb001,12,CCBS,K
+play,1,1,bryak001,21,BFBX,7/F
+play,1,1,rizza001,02,CFFX,43/G
+play,2,0,rua-r001,00,X,31/G
+play,2,0,andre001,21,CBBX,63/G
+play,2,0,chirr001,22,BCBCS,K
+play,2,1,contw001,31,BCBBX,53/G
+play,2,1,russa002,01,CX,D7/L
+play,2,1,heywj001,10,BX,43/G.2-3
+play,2,1,baezj001,32,CBFBBFX,S7/L.3-H
+play,2,1,almoa002,11,C*BX,53/G
+play,3,0,perem004,01,CX,S5/G-
+play,3,0,odorr001,20,BBX,46(1)/FO/G
+play,3,0,desmi001,11,CB1>B,CS2(24)
+play,3,0,desmi001,31,CB1>B.BB,W
+play,3,0,mazan001,00,X,8/F
+play,3,1,hendk001,12,BCFFX,3/P3F
+play,3,1,zobrb001,30,BBBB,W
+play,3,1,bryak001,00,X,9/F
+play,3,1,rizza001,01,FX,3/G+
+play,4,0,belta001,10,BX,63/G
+play,4,0,fielp001,22,CBBSH,HP
+play,4,0,rua-r001,32,BBBCCFFX,8/L
+play,4,0,andre001,12,CBSX,13/G-
+play,4,1,contw001,20,BBX,63/G
+play,4,1,russa002,10,BX,5/L
+play,4,1,heywj001,12,CBFX,7/F
+play,5,0,chirr001,32,CBCBBX,31/G+
+play,5,0,perem004,11,BCX,63/G
+play,5,0,odorr001,10,BX,8/F
+play,5,1,baezj001,00,X,23/BG
+play,5,1,almoa002,02,CFX,E5/G
+play,5,1,hendk001,01,11F1X,23/BG/SH.1-2
+play,5,1,zobrb001,12,CFFFBFX,63/G
+play,6,0,desmi001,00,X,63/G
+play,6,0,mazan001,12,BCFFX,8/F
+play,6,0,belta001,31,BBBCX,S8/L
+play,6,0,fielp001,12,CCBS,K
+play,6,1,bryak001,11,CBX,S7/L
+play,6,1,rizza001,01,CX,D8/F+.1-3
+play,6,1,contw001,31,BBCBB,W
+play,6,1,russa002,21,*BFBX,S8/G.3-H;2-H;1-3
+play,6,1,heywj001,12,1FBFX,FC3/G.3-H(E3/TH);1-3;B-2
+play,6,1,baezj001,21,CBBX,53/G
+play,6,1,almoa002,00,X,8/F
+play,6,1,hendk001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,6,1,szczm001,00,.X,S8/L.3-H;2-H(UR)
+play,6,1,zobrb001,00,,NP
+sub,barnt002,"Tony Barnette",0,9,1
+play,6,1,zobrb001,32,.CBCB11B>B,W.1-2
+play,6,1,bryak001,00,X,8/F
+play,7,0,rua-r001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,7,0,rua-r001,12,.CBSS,K
+play,7,0,andre001,32,CBBSBX,4/P-
+play,7,0,chirr001,22,CBBSS,K
+play,7,1,rizza001,12,BFFFFX,13/G
+play,7,1,contw001,32,SBFBFBC,K
+play,7,1,russa002,22,FFBFFBS,K
+play,8,0,barnt002,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,barnt002,00,,NP
+sub,profj001,"Jurickson Profar",0,9,11
+play,8,0,profj001,11,..CBX,S7/L-
+play,8,0,odorr001,12,BCSS,K
+play,8,0,desmi001,12,BFFFX,5/P5F
+play,8,0,mazan001,11,CBX,S9/G.1-2
+play,8,0,belta001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,8,0,belta001,10,.BS,WP.2-3;1-2
+play,8,0,belta001,11,.BS.X,53/G
+play,8,1,heywj001,00,,NP
+sub,leclj001,"Jose Leclerc",0,9,1
+play,8,1,heywj001,31,.SBBBB,W
+play,8,1,baezj001,11,FBX,S8/L.1-2
+play,8,1,almoa002,02,CFFX,54(1)3/GDP.2-3
+play,8,1,strop001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,8,1,lastt001,32,.BBBCFB,W
+play,8,1,zobrb001,32,BBCBC>X,7/F
+play,9,0,fielp001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,9,0,fielp001,22,.BFCBFX,341/G
+play,9,0,rua-r001,12,FCBX,9/F
+play,9,0,andre001,32,BBFBCX,8/F+
+data,er,perem004,5
+data,er,barnt002,0
+data,er,leclj001,0
+data,er,hendk001,0
+data,er,edwac001,0
+data,er,woodt004,0
+data,er,strop001,0
+data,er,grimj002,0
+id,CHN201607160
+version,2
+info,visteam,TEX
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/16
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,tumpj901
+info,ump1b,blasc901
+info,ump2b,nelsj901
+info,ump3b,diazl901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,70
+info,winddir,fromcf
+info,windspeed,10
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,167
+info,attendance,41346
+info,wp,hammj002
+info,lp,darvy001
+info,save,rondh001
+start,odorr001,"Rougned Odor",0,1,4
+start,desmi001,"Ian Desmond",0,2,8
+start,belta001,"Adrian Beltre",0,3,5
+start,morem001,"Mitch Moreland",0,4,3
+start,rua-r001,"Ryan Rua",0,5,7
+start,mazan001,"Nomar Mazara",0,6,9
+start,andre001,"Elvis Andrus",0,7,6
+start,wilsb002,"Bobby Wilson",0,8,2
+start,darvy001,"Yu Darvish",0,9,1
+start,lastt001,"Tommy La Stella",1,1,5
+start,bryak001,"Kris Bryant",1,2,9
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,contw001,"Willson Contreras",1,5,7
+start,heywj001,"Jason Heyward",1,6,8
+start,russa002,"Addison Russell",1,7,6
+start,montm001,"Miguel Montero",1,8,2
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,odorr001,00,X,8/L
+play,1,0,desmi001,02,CSX,43/G
+play,1,0,belta001,11,BSX,7/F
+play,1,1,lastt001,32,BBBCFB,W
+play,1,1,bryak001,22,BSSBC,K
+play,1,1,rizza001,22,SCBBS,K
+play,1,1,zobrb001,02,CS>S,K
+play,2,0,morem001,31,BSBBX,6/P
+play,2,0,rua-r001,01,CX,S7/L
+play,2,0,mazan001,32,BF1C*BB>S,K+SB2
+play,2,0,andre001,32,CCB*B*BFFX,S6/G.2-H;BX2(24)
+play,2,1,contw001,02,FSS,K
+play,2,1,heywj001,32,BCFBBS,K
+play,2,1,russa002,11,CBX,6/P
+play,3,0,wilsb002,22,CBBSX,63/G
+badj,darvy001,L
+play,3,0,darvy001,02,CCC,K
+play,3,0,odorr001,02,CCS,K
+play,3,1,montm001,31,BBBCB,W
+play,3,1,hammj002,02,CFC,K
+play,3,1,lastt001,11,BCX,S7/L.1-2
+play,3,1,bryak001,12,CBFS,K
+play,3,1,rizza001,12,FFBX,D9/L.2-H;1-H
+play,3,1,zobrb001,32,BBCFBX,13/G-
+play,4,0,desmi001,32,BBFFBS,K
+play,4,0,belta001,22,CSBBFFS,K
+play,4,0,morem001,22,SSBBX,D8/L
+play,4,0,rua-r001,22,CBSBS,K
+play,4,1,contw001,22,CBBSX,63/G
+play,4,1,heywj001,32,BBFFBFB,W
+play,4,1,russa002,02,CFS,K
+play,4,1,montm001,01,F>B,SB2
+play,4,1,montm001,12,F>B.FFFFS,K
+play,5,0,mazan001,32,BBBCFB,W
+play,5,0,andre001,01,1CX,54(1)3/GDP
+play,5,0,wilsb002,00,X,3/P
+play,5,1,hammj002,30,BBBB,W
+play,5,1,lastt001,22,CBFBX,9/F
+play,5,1,bryak001,11,CBX,FC5/MREV.1X2(5E4);B-1
+com,"replay,5,bryak001,CHN,nelsj901,CHI11,,N,M,TEX,C"
+com,"$when Jason Hammell was called safe at 2B, Rangers"
+com,"manager Jeff Banister challenged the ruling; the"
+com,"call was upheld by replay"
+play,5,1,rizza001,00,,NP
+sub,tolls002,"Shawn Tolleson",0,9,1
+play,5,1,rizza001,22,.BBFFFFFX,46(1)/FO/G.2-3
+play,5,1,zobrb001,32,1CCBBB>X,4/L
+play,6,0,tolls002,22,CCBBFT,K
+play,6,0,odorr001,20,BBX,7/F
+play,6,0,desmi001,00,X,13/G
+play,6,1,contw001,10,BX,S5/G-
+play,6,1,heywj001,10,BX,36(1)/FO/G
+play,6,1,russa002,21,1B11BF1X,9/L
+play,6,1,montm001,31,BBBC*B,W.1-2
+play,6,1,hammj002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,6,1,szczm001,00,.X,S8/G.2-H;1-2
+play,6,1,lastt001,00,,NP
+sub,claua001,"Alex Claudio",0,9,1
+play,6,1,lastt001,11,.BFX,9/F
+play,7,0,belta001,00,,NP
+sub,warra001,"Adam Warren",1,1,1
+play,7,0,belta001,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,7,0,belta001,32,..BBFFBFX,53/G
+play,7,0,morem001,31,CBBBX,53/G
+play,7,0,rua-r001,32,BCSBBB,W
+play,7,0,mazan001,00,,NP
+sub,woodt004,"Travis Wood",1,1,1
+play,7,0,mazan001,22,.CSBF*BC,K
+play,7,1,bryak001,00,,NP
+sub,kelak001,"Keone Kela",0,4,1
+play,7,1,bryak001,00,,NP
+sub,profj001,"Jurickson Profar",0,9,3
+play,7,1,bryak001,22,..SBCBC,K
+play,7,1,rizza001,02,CTS,K
+play,7,1,zobrb001,31,CBBBB,W
+play,7,1,contw001,22,CFB*BS,K
+play,8,0,andre001,12,CBTX,53/G
+play,8,0,wilsb002,00,X,53/G+
+play,8,0,profj001,32,CFBFFBBT,K
+play,8,1,heywj001,00,,NP
+sub,bushm001,"Matt Bush",0,4,1
+play,8,1,heywj001,01,.CX,7/F
+play,8,1,russa002,12,BTFX,3/L-
+play,8,1,montm001,02,CSX,53/G
+play,9,0,odorr001,00,,NP
+sub,almoa002,"Albert Almora",1,1,8
+play,9,0,odorr001,00,,NP
+sub,bryak001,"Kris Bryant",1,2,7
+play,9,0,odorr001,00,,NP
+sub,contw001,"Willson Contreras",1,5,2
+play,9,0,odorr001,00,,NP
+sub,heywj001,"Jason Heyward",1,6,9
+play,9,0,odorr001,00,,NP
+sub,rondh001,"Hector Rondon",1,8,1
+play,9,0,odorr001,22,.....CBFBFX,9/F
+play,9,0,desmi001,00,X,13/G
+play,9,0,belta001,02,SCX,9/F
+data,er,darvy001,2
+data,er,tolls002,1
+data,er,claua001,0
+data,er,kelak001,0
+data,er,bushm001,0
+data,er,hammj002,1
+data,er,warra001,0
+data,er,woodt004,0
+data,er,rondh001,0
+id,CHN201607170
+version,2
+info,visteam,TEX
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/17
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,blasc901
+info,ump1b,nelsj901
+info,ump2b,diazl901
+info,ump3b,tumpj901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,speaa701
+info,temp,79
+info,winddir,tocf
+info,windspeed,18
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,137
+info,attendance,41213
+info,wp,hamec001
+info,lp,lackj001
+info,save,dysos001
+start,odorr001,"Rougned Odor",0,1,4
+start,desmi001,"Ian Desmond",0,2,8
+start,belta001,"Adrian Beltre",0,3,5
+start,fielp001,"Prince Fielder",0,4,3
+start,rua-r001,"Ryan Rua",0,5,7
+start,mazan001,"Nomar Mazara",0,6,9
+start,andre001,"Elvis Andrus",0,7,6
+start,chirr001,"Robinson Chirinos",0,8,2
+start,hamec001,"Cole Hamels",0,9,1
+start,baezj001,"Javier Baez",1,1,4
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,contw001,"Willson Contreras",1,4,2
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,szczm001,"Matt Szczur",1,7,7
+start,almoa002,"Albert Almora",1,8,8
+start,lackj001,"John Lackey",1,9,1
+play,1,0,odorr001,12,BSSX,7/F
+play,1,0,desmi001,02,CSC,K
+play,1,0,belta001,01,CX,53/G
+play,1,1,baezj001,12,CFFBC,K
+play,1,1,bryak001,12,BFSS,K
+play,1,1,rizza001,02,CSS,K
+play,2,0,fielp001,11,BFX,S9/L
+play,2,0,rua-r001,01,CX,S7/L.1-2
+play,2,0,mazan001,22,BBSCFC,K
+play,2,0,andre001,10,BX,S8/L.2-H;1-3
+play,2,0,chirr001,00,X,8/F/SF.3-H
+play,2,0,hamec001,11,BFX,S7/L.1-3
+play,2,0,odorr001,02,CFX,9/F
+play,2,1,contw001,12,CFBFFFC,K
+play,2,1,russa002,12,SBSS,K
+play,2,1,heywj001,22,FBFBS,K
+play,3,0,desmi001,00,X,7/F
+play,3,0,belta001,12,CBFX,53/G
+play,3,0,fielp001,12,FBCS,K
+play,3,1,szczm001,21,BSBX,4/P
+play,3,1,almoa002,01,FX,E5/G
+play,3,1,lackj001,12,F1FBX,4/P
+play,3,1,baezj001,00,X,D7/L.1-H(UR)
+play,3,1,bryak001,01,F>S,SB3
+play,3,1,bryak001,02,F>S.C,K
+play,4,0,rua-r001,32,SCBBBB,W
+play,4,0,mazan001,30,1B1BBB,W.1-2
+play,4,0,andre001,12,SL*BS,K
+play,4,0,chirr001,00,X,D7/F.2-H;1-3
+play,4,0,hamec001,01,LX,53/BG
+play,4,0,odorr001,22,BBCSS,K
+play,4,1,rizza001,00,X,3/G
+play,4,1,contw001,31,BBCBX,5/P5F
+play,4,1,russa002,02,SSX,8/F
+play,5,0,desmi001,12,CBCX,3/G
+play,5,0,belta001,22,FFBBX,4/L-
+play,5,0,fielp001,12,SSBS,K
+play,5,1,heywj001,11,BFX,8/F
+play,5,1,szczm001,00,X,9/F
+play,5,1,almoa002,20,BBX,53/G
+play,6,0,rua-r001,00,X,63/G
+play,6,0,mazan001,12,CBSS,K
+play,6,0,andre001,22,BCCFBFX,8/F
+play,6,1,lackj001,01,CX,7/F
+play,6,1,baezj001,10,BX,8/F
+play,6,1,bryak001,12,BFCX,S8/F-
+play,6,1,rizza001,22,BBCSX,31/G
+play,7,0,chirr001,02,CSFFX,8/F
+play,7,0,hamec001,31,BBCBX,31/G
+play,7,0,odorr001,21,BSBX,43/G
+play,7,1,contw001,00,X,S7/L
+play,7,1,russa002,01,SX,S8/L.1-2
+play,7,1,heywj001,10,BX,3/L/DP.1X1(3)
+play,7,1,szczm001,22,SBBFX,13/G
+play,8,0,desmi001,11,CBX,HR/7/F
+play,8,0,belta001,02,SSS,K
+play,8,0,fielp001,00,X,43/G
+play,8,0,rua-r001,32,CBBBCX,8/F
+play,8,1,almoa002,00,,NP
+sub,morem001,"Mitch Moreland",0,4,3
+play,8,1,almoa002,10,.BX,6/L
+play,8,1,lackj001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,8,1,lastt001,22,.CBSBX,31/G
+play,8,1,baezj001,11,BSX,7/F
+play,9,0,mazan001,00,,NP
+sub,richc002,"Clayton Richard",1,1,1
+play,9,0,mazan001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,4
+play,9,0,mazan001,12,..CBTX,13/G
+play,9,0,andre001,22,CBCBS,K
+play,9,0,chirr001,32,CBBBSX,53/G
+play,9,1,bryak001,00,,NP
+sub,dysos001,"Sam Dyson",0,9,1
+play,9,1,bryak001,22,.FSBBS,K
+play,9,1,rizza001,02,CCT,K
+play,9,1,contw001,22,CBCFFBFS,K
+data,er,hamec001,0
+data,er,dysos001,0
+data,er,lackj001,4
+data,er,richc002,0
+id,CHN201607180
+version,2
+info,visteam,NYN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/18
+info,number,0
+info,starttime,6:10PM
+info,daynight,night
+info,usedh,false
+info,umphome,cedeg901
+info,ump1b,coope901
+info,ump2b,wolfj901
+info,ump3b,morag901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,75
+info,winddir,fromlf
+info,windspeed,11
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,176
+info,attendance,41353
+info,wp,lestj001
+info,lp,matzs001
+info,save,rondh001
+start,reyej001,"Jose Reyes",0,1,5
+start,granc001,"Curtis Granderson",0,2,9
+start,cespy001,"Yoenis Cespedes",0,3,7
+start,walkn001,"Neil Walker",0,4,4
+start,florw001,"Wilmer Flores",0,5,3
+start,cabra002,"Asdrubal Cabrera",0,6,6
+start,lagaj001,"Juan Lagares",0,7,8
+start,darnt001,"Travis d'Arnaud",0,8,2
+start,matzs001,"Steven Matz",0,9,1
+start,baezj001,"Javier Baez",1,1,4
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,contw001,"Willson Contreras",1,4,7
+start,russa002,"Addison Russell",1,5,6
+start,szczm001,"Matt Szczur",1,6,9
+start,almoa002,"Albert Almora",1,7,8
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,reyej001,12,BCFS,K
+play,1,0,granc001,11,BCX,3/G
+play,1,0,cespy001,02,CSS,K
+play,1,1,baezj001,20,BBX,S8/G
+play,1,1,bryak001,22,CBSB1FC,K
+play,1,1,rizza001,11,FBX,3/G.1-2
+play,1,1,contw001,12,BCFS,K
+play,2,0,walkn001,31,BBBC*B,W
+play,2,0,florw001,00,X,S8/L-.1-2
+play,2,0,cabra002,11,SBX,54(1)3/GDP.2-3
+play,2,0,lagaj001,01,CX,63/G
+play,2,1,russa002,32,CBBFBFFX,S7/L
+play,2,1,szczm001,02,SF1S,K
+play,2,1,almoa002,32,B*BCBFFX,7/F
+play,2,1,rossd001,22,1CBB1CX,64(1)/FO/G
+play,3,0,darnt001,01,CX,53/G
+play,3,0,matzs001,32,BBCBFB,W
+play,3,0,reyej001,11,SBX,S8/G.1-2
+play,3,0,granc001,21,*BBCX,56(1)/FO/G.2-3
+play,3,0,cespy001,12,CBFX,6/L
+play,3,1,lestj001,02,CSC,K
+play,3,1,baezj001,00,X,S7/L
+play,3,1,bryak001,01,F1>S,SB2
+play,3,1,bryak001,12,F1>S.BH,HP
+play,3,1,rizza001,22,BBFCFFFFFX,HR/89/L.2-H;1-H
+play,3,1,contw001,00,X,DGR/7/L+
+play,3,1,russa002,20,BBX,8/L
+play,3,1,szczm001,01,F2X,S7/G.2XH(72)
+play,4,0,walkn001,01,CX,43/G
+play,4,0,florw001,32,BBBCCX,7/F
+play,4,0,cabra002,11,BFX,63/G
+play,4,1,almoa002,01,CX,63/G
+play,4,1,rossd001,31,BBBCB,W
+play,4,1,lestj001,02,LCX,13/BG/SH.1-2
+play,4,1,baezj001,02,CSFFX,9/F
+play,5,0,lagaj001,22,BSBFX,43/G
+play,5,0,darnt001,32,SFFBBBB,W
+play,5,0,matzs001,10,BX,24/BG/SH.1-2
+play,5,0,reyej001,21,CBBX,53/G
+play,5,1,bryak001,31,BFBBX,S7/L
+play,5,1,rizza001,11,CB11X,8/F
+play,5,1,contw001,12,FFB>B,SB2
+play,5,1,contw001,22,FFB>B.S,K
+play,5,1,russa002,02,FCX,8/F
+play,6,0,granc001,12,CCBX,4/L
+play,6,0,cespy001,00,X,9/F
+play,6,0,walkn001,00,X,8/F
+play,6,1,szczm001,32,BCBCFFBX,D7/L+
+play,6,1,almoa002,00,,NP
+sub,lugos001,"Seth Lugo",0,9,1
+play,6,1,almoa002,02,.LLX,43/G.2-3
+play,6,1,rossd001,32,PFFFBBFX,8/F/SF.3-H
+play,6,1,lestj001,11,BFX,43/G
+play,7,0,florw001,10,BX,HR/78/L
+play,7,0,cabra002,12,CFBFT,K
+play,7,0,lagaj001,21,BFBX,53/G
+play,7,0,darnt001,00,X,4/P
+play,7,1,baezj001,02,SFFX,8/F
+play,7,1,bryak001,11,SBX,7/L+
+play,7,1,rizza001,12,BFFC,K
+play,8,0,lugos001,00,,NP
+sub,johnk003,"Kelly Johnson",0,9,11
+play,8,0,johnk003,01,.SX,3/G
+play,8,0,reyej001,22,BCSBX,8/F
+play,8,0,granc001,21,BBFX,S9/L
+play,8,0,cespy001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,8,0,cespy001,12,.BSFH,HP.1-2
+play,8,0,walkn001,22,BC*BFS,K
+play,8,1,contw001,00,,NP
+sub,goede001,"Erik Goeddel",0,9,1
+play,8,1,contw001,02,.SSS,K
+play,8,1,russa002,32,BSSBFBS,K
+play,8,1,szczm001,22,BCBSX,D7/G+
+play,8,1,almoa002,11,BCX,S7/L+.2-H;B-3(E7)
+play,8,1,rossd001,12,CBCFX,8/F
+play,9,0,florw001,00,,NP
+sub,edwac001,"Carl Edwards",1,4,1
+play,9,0,florw001,00,,NP
+sub,szczm001,"Matt Szczur",1,6,7
+play,9,0,florw001,00,,NP
+sub,heywj001,"Jason Heyward",1,9,9
+play,9,0,florw001,12,...BFFX,31/G
+play,9,0,cabra002,21,BBCX,S8/G
+play,9,0,lagaj001,00,,NP
+sub,confm001,"Michael Conforto",0,7,11
+play,9,0,confm001,11,.BCX,S7/G.1-2
+play,9,0,darnt001,00,,NP
+sub,rondh001,"Hector Rondon",1,4,1
+play,9,0,darnt001,22,.CBCBFX,4(1)3/GDP
+data,er,matzs001,4
+data,er,lugos001,0
+data,er,goede001,1
+data,er,lestj001,1
+data,er,strop001,0
+data,er,edwac001,0
+data,er,rondh001,0
+id,CHN201607190
+version,2
+info,visteam,NYN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/19
+info,number,0
+info,starttime,6:10PM
+info,daynight,night
+info,usedh,false
+info,umphome,coope901
+info,ump1b,wolfj901
+info,ump2b,morag901
+info,ump3b,cedeg901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,76
+info,winddir,fromcf
+info,windspeed,11
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,184
+info,attendance,41456
+info,wp,roblh001
+info,lp,rondh001
+info,save,famij001
+start,reyej001,"Jose Reyes",0,1,5
+start,granc001,"Curtis Granderson",0,2,8
+start,cespy001,"Yoenis Cespedes",0,3,7
+start,lonej001,"James Loney",0,4,3
+start,walkn001,"Neil Walker",0,5,4
+start,cabra002,"Asdrubal Cabrera",0,6,6
+start,confm001,"Michael Conforto",0,7,9
+start,river003,"Rene Rivera",0,8,2
+start,syndn001,"Noah Syndergaard",0,9,1
+start,lastt001,"Tommy La Stella",1,1,5
+start,bryak001,"Kris Bryant",1,2,9
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,contw001,"Willson Contreras",1,5,7
+start,heywj001,"Jason Heyward",1,6,8
+start,russa002,"Addison Russell",1,7,6
+start,montm001,"Miguel Montero",1,8,2
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,reyej001,12,CFBT,K
+play,1,0,granc001,01,CX,5/L-
+play,1,0,cespy001,00,X,S7/G
+play,1,0,lonej001,00,X,13/G
+play,1,1,lastt001,20,BBX,S8/L
+play,1,1,bryak001,10,BX,S4/G.1-2
+play,1,1,rizza001,12,BFFFS,K
+play,1,1,zobrb001,12,CBCB,WP.2-3;1-2
+play,1,1,zobrb001,22,CBCB.X,7/F-
+play,1,1,contw001,00,X,63/G
+play,2,0,walkn001,01,CX,43/G
+play,2,0,cabra002,02,FLS,K
+play,2,0,confm001,02,CCFC,K
+play,2,1,heywj001,22,CSBFBX,S9/L+
+play,2,1,russa002,21,FB1B11>X,D7/L.1-3
+play,2,1,montm001,01,FX,FC1/G.3XH(125)
+play,2,1,arrij001,22,SBC*BS,K
+play,2,1,lastt001,32,FBBBF*B,W.2-3;1-2
+play,2,1,bryak001,00,X,8/L
+play,3,0,river003,01,CX,9/F
+play,3,0,syndn001,12,BFFS,K
+play,3,0,reyej001,02,FFFS,K
+play,3,1,rizza001,12,BSCFFFS,K
+play,3,1,zobrb001,22,CBCBC,K
+play,3,1,contw001,21,BBSX,D9/L
+play,3,1,heywj001,11,BCB,WP.2-H(UR)(E2/TH)(NR)
+play,3,1,heywj001,21,BCB.X,7/F
+play,4,0,granc001,22,CBSBX,9/F
+play,4,0,cespy001,10,BX,53/G
+play,4,0,lonej001,11,FBX,8/L
+play,4,1,russa002,12,CBSFX,43/G
+play,4,1,montm001,32,BBFBSS,K
+play,4,1,arrij001,21,BBCX,D8/L+
+play,4,1,lastt001,12,BCFX,S9/L/MREV.2XH(92)
+com,"replay,4,lastt001,CHN,cedeg901,CHI11,,Y,M,NYN,A"
+com,"$when Jake Arrieta was called safe at HP, Mets"
+com,"manager Terry Collins challenged the ruling; the"
+com,"call was overturned by replay"
+play,5,0,walkn001,00,X,8/L
+play,5,0,cabra002,10,BX,43/G-
+play,5,0,confm001,32,CSBBBB,W
+play,5,0,river003,01,FX,S7/L-.1-2
+play,5,0,syndn001,12,BSFS,K
+play,5,1,bryak001,01,CX,6/P
+play,5,1,rizza001,12,FBFS,K
+play,5,1,zobrb001,32,BCBBCX,7/L
+play,6,0,reyej001,12,FFFBX,T9/L+
+play,6,0,granc001,01,CX,8/F/SF.3-H
+play,6,0,cespy001,32,CBBFBX,53/G
+play,6,0,lonej001,12,CBFX,3/G
+play,6,1,contw001,30,BBBB,W
+play,6,1,heywj001,21,BBF>S,SB2
+play,6,1,heywj001,22,BBF>S.S,K23
+play,6,1,russa002,12,*BSCFS,K
+play,6,1,montm001,00,,NP
+sub,blevj001,"Jerry Blevins",0,9,1
+play,6,1,montm001,32,.BBFFBX,8/F
+play,7,0,walkn001,10,BX,S9/L
+play,7,0,cabra002,12,FL1BS,K
+play,7,0,confm001,10,BX,4/P3F
+play,7,0,river003,12,SC*BX,S7/L.1-2
+play,7,0,blevj001,00,,NP
+sub,deaza001,"Alejandro de Aza",0,9,11
+play,7,0,deaza001,12,.BCCS,K
+play,7,1,arrij001,00,,NP
+sub,roblh001,"Hansel Robles",0,9,1
+play,7,1,arrij001,00,,NP
+sub,baezj001,"Javier Baez",1,9,11
+play,7,1,baezj001,12,..BFSX,53/G
+play,7,1,lastt001,00,X,7/F
+play,7,1,bryak001,01,CX,S7/G
+play,7,1,rizza001,02,1CF1T,K
+play,8,0,reyej001,00,,NP
+sub,strop001,"Pedro Strop",1,1,1
+play,8,0,reyej001,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,8,0,reyej001,10,..BX,63/G
+play,8,0,granc001,12,CBSX,23/G-
+play,8,0,cespy001,02,SCS,K
+play,8,1,zobrb001,00,X,1/L+
+play,8,1,contw001,22,CBBCX,53/G
+play,8,1,heywj001,11,FBX,43/G
+play,9,0,lonej001,00,,NP
+sub,rondh001,"Hector Rondon",1,1,1
+play,9,0,lonej001,12,.CCBX,S7/L
+play,9,0,walkn001,22,CCB+1FFBFX,36(1)/FO/G/MREV
+com,"replay,9,walkn001,NYN,cedeg901,CHI11,,Y,M,NYN,C"
+com,"$when Neal Walker was called out at 1B, Mets"
+com,"manager Terry Collins challenged the ruling; the"
+com,"call was overturned by replay"
+play,9,0,cabra002,01,1S1X,S9/G.1-2
+play,9,0,confm001,02,FFS,K
+play,9,0,river003,00,X,S9/L.2-H;1-3
+play,9,0,roblh001,00,,NP
+sub,johnk003,"Kelly Johnson",0,9,11
+play,9,0,johnk003,11,.C*BX,43/G
+play,9,1,russa002,00,,NP
+sub,granc001,"Curtis Granderson",0,2,9
+play,9,1,russa002,00,,NP
+sub,lagaj001,"Juan Lagares",0,7,8
+play,9,1,russa002,00,,NP
+sub,famij001,"Jeurys Familia",0,9,1
+play,9,1,russa002,32,...CFBBBB,W
+play,9,1,montm001,30,B1BBB,W.1-2
+play,9,1,baezj001,00,,NP
+sub,almoa002,"Albert Almora",1,8,12
+play,9,1,baezj001,11,.BCX,S5/BG.2-3;1-2
+play,9,1,rondh001,00,,NP
+sub,szczm001,"Matt Szczur",1,1,11
+play,9,1,szczm001,12,.SFFBFX,32(3)/FO/G.2-3;1-2
+play,9,1,bryak001,11,BSX,54(1)3/GDP
+data,er,syndn001,0
+data,er,blevj001,0
+data,er,roblh001,0
+data,er,famij001,0
+data,er,arrij001,1
+data,er,strop001,0
+data,er,rondh001,1
+id,CHN201607200
+version,2
+info,visteam,NYN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/20
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,wolfj901
+info,ump1b,morag901
+info,ump2b,cedeg901
+info,ump3b,coope901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,85
+info,winddir,rtol
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,169
+info,attendance,41210
+info,wp,hendk001
+info,lp,colob001
+info,save,
+start,reyej001,"Jose Reyes",0,1,6
+start,granc001,"Curtis Granderson",0,2,9
+start,florw001,"Wilmer Flores",0,3,5
+start,lonej001,"James Loney",0,4,3
+start,darnt001,"Travis d'Arnaud",0,5,2
+start,johnk003,"Kelly Johnson",0,6,4
+start,lagaj001,"Juan Lagares",0,7,8
+start,confm001,"Michael Conforto",0,8,7
+start,colob001,"Bartolo Colon",0,9,1
+start,zobrb001,"Ben Zobrist",1,1,9
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,contw001,"Willson Contreras",1,4,7
+start,heywj001,"Jason Heyward",1,5,8
+start,russa002,"Addison Russell",1,6,6
+start,montm001,"Miguel Montero",1,7,2
+start,baezj001,"Javier Baez",1,8,4
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,reyej001,12,CSBFS,K
+play,1,0,granc001,12,CLBL,K/BF
+play,1,0,florw001,22,FCBBS,K
+play,1,1,zobrb001,21,BBCX,13/G
+play,1,1,bryak001,32,CBBBFFX,S5/G-
+play,1,1,rizza001,00,X,8/F
+play,1,1,contw001,22,C11BFBF1>B,SB2
+play,1,1,contw001,32,C11BFBF1>B.B,W
+play,1,1,heywj001,31,BCBBB,W.2-3;1-2
+play,1,1,russa002,22,CFBBX,D7/L.3-H;2-H;1-3
+play,1,1,montm001,21,FBBX,7/L
+play,2,0,lonej001,12,FBCX,4/L-
+play,2,0,darnt001,10,BX,D7/G+
+play,2,0,johnk003,02,CCX,S3/G-.2-3
+play,2,0,lagaj001,10,BX,54(1)3/GDP
+play,2,1,baezj001,00,X,8/F
+play,2,1,hendk001,12,BCCS,K
+play,2,1,zobrb001,21,CBBX,43/G
+play,3,0,confm001,22,FBBCC,K
+play,3,0,colob001,02,CCS,K
+play,3,0,reyej001,12,FSBC,K
+play,3,1,bryak001,02,SFX,63/G
+play,3,1,rizza001,20,BBX,HR/89/F
+play,3,1,contw001,01,CX,53/G
+play,3,1,heywj001,11,BFX,3/P3F
+play,4,0,granc001,02,CSX,53/G
+play,4,0,florw001,22,CSBBFX,63/G
+play,4,0,lonej001,20,BBX,S7/G
+play,4,0,darnt001,01,CX,S8/L.1-2
+play,4,0,johnk003,11,BFX,S8/L.2XH(82);1-2
+play,4,1,russa002,02,FFH,HP
+play,4,1,montm001,20,11B1BX,8/F
+play,4,1,baezj001,00,X,S7/G.1-2
+play,4,1,hendk001,11,BFX,14/BG/SH.2-3;1-2
+play,4,1,zobrb001,01,CX,63/G
+play,5,0,lagaj001,11,BCX,43/G
+play,5,0,confm001,20,BBX,D8/L
+play,5,0,colob001,01,CX,53/G
+play,5,0,reyej001,21,BSBX,8/L
+play,5,1,bryak001,12,CBFX,D9/L
+play,5,1,rizza001,10,BX,HR/89/L.2-H
+play,5,1,contw001,01,FX,S56/G
+play,5,1,heywj001,11,BCX,13/G-.1-2
+play,5,1,russa002,32,BBFFBX,S6/G.2-3
+play,5,1,montm001,00,,NP
+sub,basta001,"Antonio Bastardo",0,9,1
+play,5,1,montm001,02,.CC1S,K
+play,5,1,baezj001,10,BX,S57/G.3-H;1-2
+play,5,1,hendk001,22,BFF*BFS,K
+play,6,0,granc001,22,BCSBS,K
+play,6,0,florw001,12,CBCX,43/G
+play,6,0,lonej001,10,BX,8/F
+play,6,1,zobrb001,12,BCCX,53/G
+play,6,1,bryak001,32,BBBCFX,3/P
+play,6,1,rizza001,02,FFX,8/F
+play,7,0,darnt001,31,BFBBB,W
+play,7,0,johnk003,00,X,S8/L.1-2
+play,7,0,lagaj001,22,CBSFBX,4/P3F
+play,7,0,confm001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,7,0,confm001,01,.CX,46(1)3/GDP
+play,7,1,contw001,00,,NP
+sub,goede001,"Erik Goeddel",0,9,1
+play,7,1,contw001,02,.SSS,K
+play,7,1,heywj001,21,BBCX,4/L-
+play,7,1,russa002,22,CBFBX,S8/G
+play,7,1,montm001,21,*BBSX,4/P
+play,8,0,goede001,00,,NP
+sub,deaza001,"Alejandro de Aza",0,9,11
+play,8,0,deaza001,12,.CCBX,3/G
+play,8,0,reyej001,32,BCBSBFB,W
+play,8,0,granc001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,1,7
+play,8,0,granc001,00,,NP
+sub,woodt004,"Travis Wood",1,4,1
+play,8,0,granc001,00,,NP
+sub,heywj001,"Jason Heyward",1,5,9
+play,8,0,granc001,00,,NP
+sub,almoa002,"Albert Almora",1,9,8
+play,8,0,granc001,12,....BCSX,9/F
+play,8,0,florw001,20,BB>X,HR/7/F.1-H
+play,8,0,lonej001,22,FBBFX,7/L
+play,8,1,baezj001,00,,NP
+sub,reeda001,"Addison Reed",0,2,1
+play,8,1,baezj001,00,,NP
+sub,deaza001,"Alejandro de Aza",0,9,9
+play,8,1,baezj001,22,..BSCBS,K
+play,8,1,almoa002,02,FFX,S9/L
+play,8,1,zobrb001,21,FBBX,8/F
+play,8,1,bryak001,22,SSBF*BS,K
+play,9,0,darnt001,00,,NP
+sub,rondh001,"Hector Rondon",1,4,1
+play,9,0,darnt001,10,.BX,4/P
+play,9,0,johnk003,00,X,S7/G
+play,9,0,lagaj001,02,CCB,WP.1-2
+play,9,0,lagaj001,12,CCB.FS,K
+play,9,0,confm001,01,FX,8/F
+data,er,colob001,6
+data,er,basta001,0
+data,er,goede001,0
+data,er,reeda001,0
+data,er,hendk001,0
+data,er,edwac001,1
+data,er,woodt004,1
+data,er,rondh001,0
+id,CHN201607270
+version,2
+info,visteam,CHA
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/27
+info,number,0
+info,starttime,7:09PM
+info,daynight,night
+info,usedh,false
+info,umphome,wendh902
+info,ump1b,laynj901
+info,ump2b,barrs901
+info,ump3b,gibsh902
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,78
+info,winddir,fromrf
+info,windspeed,12
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,171
+info,attendance,41166
+info,wp,hammj002
+info,lp,ranaa001
+info,save,
+start,eatoa002,"Adam Eaton",0,1,9
+start,andet001,"Tim Anderson",0,2,6
+start,cabrm002,"Melky Cabrera",0,3,7
+start,abrej003,"Jose Abreu",0,4,3
+start,frazt001,"Todd Frazier",0,5,5
+start,shucj001,"J.B. Shuck",0,6,8
+start,navad001,"Dioner Navarro",0,7,2
+start,salat001,"Tyler Saladino",0,8,4
+start,ranaa001,"Anthony Ranaudo",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,7
+start,montm001,"Miguel Montero",1,5,2
+start,russa002,"Addison Russell",1,6,6
+start,heywj001,"Jason Heyward",1,7,9
+start,baezj001,"Javier Baez",1,8,4
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,eatoa002,12,BCFS,K
+play,1,0,andet001,00,X,63/G
+play,1,0,cabrm002,30,BBBB,W
+play,1,0,abrej003,32,B1BBCS>S,K
+play,1,1,fowld001,31,BBBCB,W
+play,1,1,bryak001,10,BX,3/P3F
+play,1,1,rizza001,30,B1*BBB,W.1-2
+play,1,1,zobrb001,22,CBBFFX,13/G-.2-3;1-2
+play,1,1,montm001,20,BBX,43/G
+play,2,0,frazt001,00,X,S57/L+
+play,2,0,shucj001,10,B1X,7/F
+play,2,0,navad001,00,1,OA/MREV
+com,"replay,2,navad001,CHA,laynj901,CHI11,,Y,M,CHA,A"
+com,"$when Todd Frazier was called out at 1B on a pickoff"
+com,"attempt, White Sox manager Robin Ventura challenged"
+com,"the ruling; the call was overturned by replay"
+play,2,0,navad001,22,111BB1CS+1FX,7/F
+play,2,0,salat001,12,SBC>X,9/F
+play,2,1,russa002,01,CX,9/F
+play,2,1,heywj001,01,CX,7/L+
+play,2,1,baezj001,22,CFBFBX,53/G
+play,3,0,ranaa001,12,BCFX,43/G
+play,3,0,eatoa002,00,X,63/G+
+play,3,0,andet001,11,BCX,S8/L
+play,3,0,cabrm002,00,1>B,SB2
+play,3,0,cabrm002,12,1>B.CFS,K
+play,3,1,hammj002,02,CCX,53/G-
+play,3,1,fowld001,12,BCSFS,K
+play,3,1,bryak001,22,BFBCFX,63/G
+play,4,0,abrej003,11,BSX,9/F9LF
+play,4,0,frazt001,32,CFBFBBX,D9/L+
+play,4,0,shucj001,32,BCS*BB*B,W
+play,4,0,navad001,10,BX,8/F.2-3
+play,4,0,salat001,22,BCCFBFS,K
+play,4,1,rizza001,32,BCBBCT,K
+play,4,1,zobrb001,11,CBX,43/G
+play,4,1,montm001,32,CBBBSB,W
+play,4,1,russa002,22,FBCBX,3/P
+play,5,0,ranaa001,01,CX,HR/89/L+
+play,5,0,eatoa002,22,CBFBX,7/F-
+play,5,0,andet001,12,BFTX,63/G
+play,5,0,cabrm002,02,CFFX,8/F
+play,5,1,heywj001,11,BCX,31/G
+play,5,1,baezj001,01,SX,8/L
+play,5,1,hammj002,02,FSS,K
+play,6,0,abrej003,02,CCX,S9/G+
+play,6,0,frazt001,22,CCBBX,54(1)3/GDP
+play,6,0,shucj001,01,CX,53/G
+play,6,1,fowld001,00,X,8/F
+play,6,1,bryak001,31,BBFBX,HR/78/F+
+play,6,1,rizza001,12,FFFBX,9/F
+play,6,1,zobrb001,22,CBBCFX,7/F
+play,7,0,navad001,12,CSBS,K
+play,7,0,salat001,02,CCFC,K
+play,7,0,ranaa001,22,CBBCS,K
+play,7,1,montm001,12,CBSX,53/G
+play,7,1,russa002,01,CX,63/G
+play,7,1,heywj001,32,CFBBBB,W
+play,7,1,baezj001,32,BBS1FB>X,HR/7/F+.1-H
+play,7,1,hammj002,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,7,1,lastt001,00,,NP
+sub,dukez001,"Zach Duke",0,9,1
+play,7,1,lastt001,32,..CBCBBB,W
+play,7,1,fowld001,00,,NP
+sub,fulmc001,"Carson Fulmer",0,9,1
+play,7,1,fowld001,22,.FCB*BX,3/G
+play,8,0,eatoa002,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,8,0,eatoa002,11,.CBX,3/L
+play,8,0,andet001,00,X,63/G
+play,8,0,cabrm002,11,CBX,7/L
+play,8,1,bryak001,00,H,HP
+play,8,1,rizza001,22,BBTFFX,S8/L.1-3
+play,8,1,zobrb001,31,BCB*BX,D87/F.3-H;1-3
+play,8,1,montm001,30,BBBB,W
+play,8,1,russa002,00,,NP
+sub,turnj002,"Jacob Turner",0,9,1
+play,8,1,russa002,10,.BX,HR/78/L+.3-H;2-H;1-H
+play,8,1,heywj001,12,FBFX,S9/L-
+play,8,1,baezj001,01,CX,9/F
+play,8,1,rondh001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,8,1,szczm001,11,.BCX,9/F-
+play,8,1,fowld001,32,BFFF*BB>S,K
+play,9,0,abrej003,00,,NP
+sub,chapa001,"Aroldis Chapman",1,1,1
+play,9,0,abrej003,00,,NP
+sub,szczm001,"Matt Szczur",1,9,8
+play,9,0,abrej003,02,..CFFS,K
+play,9,0,frazt001,32,BFBSBX,63/G
+play,9,0,shucj001,00,,NP
+sub,garca003,"Avisail Garcia",0,6,11
+play,9,0,garca003,22,.BSFBC,K
+data,er,ranaa001,3
+data,er,dukez001,0
+data,er,fulmc001,4
+data,er,turnj002,1
+data,er,hammj002,1
+data,er,rondh001,0
+data,er,chapa001,0
+id,CHN201607280
+version,2
+info,visteam,CHA
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/28
+info,number,0
+info,starttime,7:07PM
+info,daynight,night
+info,usedh,false
+info,umphome,laynj901
+info,ump1b,barrs901
+info,ump2b,gibsh902
+info,ump3b,wendh902
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,73
+info,winddir,fromlf
+info,windspeed,8
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,171
+info,attendance,41157
+info,wp,lackj001
+info,lp,salec001
+info,save,chapa001
+start,eatoa002,"Adam Eaton",0,1,9
+start,andet001,"Tim Anderson",0,2,6
+start,cabrm002,"Melky Cabrera",0,3,7
+start,abrej003,"Jose Abreu",0,4,3
+start,frazt001,"Todd Frazier",0,5,5
+start,shucj001,"J.B. Shuck",0,6,8
+start,navad001,"Dioner Navarro",0,7,2
+start,sancc001,"Carlos Sanchez",0,8,4
+start,salec001,"Chris Sale",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,9
+start,contw001,"Willson Contreras",1,5,2
+start,russa002,"Addison Russell",1,6,6
+start,baezj001,"Javier Baez",1,7,4
+start,szczm001,"Matt Szczur",1,8,7
+start,lackj001,"John Lackey",1,9,1
+play,1,0,eatoa002,22,CBBTFFFS,K
+play,1,0,andet001,11,CBX,S5/G-
+play,1,0,cabrm002,00,X,D9/L+.1-H
+play,1,0,abrej003,01,CX,13/G-
+play,1,0,frazt001,21,CBBX,3/P
+play,1,1,fowld001,32,CCBBBFFFB,W
+play,1,1,bryak001,11,BSX,D8/F.1-H
+play,1,1,rizza001,01,CX,43/G.2-3
+play,1,1,zobrb001,11,CBX,6/L+
+play,1,1,contw001,12,CSBX,63/G
+play,2,0,shucj001,12,CBFX,63/G
+play,2,0,navad001,31,BBBCB,W
+play,2,0,sancc001,02,CFX,64(1)3/GDP
+play,2,1,russa002,32,BBFFBFFX,3/P2F
+play,2,1,baezj001,12,CBFX,S9/G
+play,2,1,szczm001,02,1CFX,7/F
+play,2,1,lackj001,11,BCX,13/G
+play,3,0,salec001,11,BCX,43/G
+play,3,0,eatoa002,22,BCFBFX,8/L
+play,3,0,andet001,10,BX,8/F
+play,3,1,fowld001,01,FH,HP
+play,3,1,bryak001,30,BBBB,W.1-2
+play,3,1,rizza001,10,BX,7/F
+play,3,1,zobrb001,22,FCBBFX,S8/G+.2-H;1-3
+play,3,1,contw001,22,BBSFFFX,6(1)3/GDP
+play,4,0,cabrm002,22,CCFBBFS,K
+play,4,0,abrej003,11,CBX,53/G
+play,4,0,frazt001,12,BCSS,K
+play,4,1,russa002,10,BX,23/G-
+play,4,1,baezj001,02,CFFC,K
+play,4,1,szczm001,31,BBBCX,7/L+
+play,5,0,shucj001,20,BBX,6/P7LF
+play,5,0,navad001,22,BCCBX,63/G
+play,5,0,sancc001,21,BSBX,43/G
+play,5,1,lackj001,02,CFC,K
+play,5,1,fowld001,21,BBCX,S8/L+
+play,5,1,bryak001,12,FBSFC,K
+play,5,1,rizza001,32,BBBCS>X,S5/P.1-3
+play,5,1,zobrb001,02,FFX,13/G
+play,6,0,salec001,01,CX,S4/G
+play,6,0,eatoa002,01,CX,7/L+
+play,6,0,andet001,22,*BBCSS,K
+play,6,0,cabrm002,00,X,S9/L+.1-2
+play,6,0,abrej003,32,B*BFF*B>F>X,3/P
+play,6,1,contw001,00,X,63/G
+play,6,1,russa002,02,SSX,D7/L+
+play,6,1,baezj001,22,BSBFX,53/G
+play,6,1,szczm001,30,IIII,IW
+play,6,1,lackj001,00,,NP
+sub,rossd001,"David Ross",1,9,11
+play,6,1,rossd001,22,.BCBSFC,K
+play,7,0,frazt001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,7,0,frazt001,20,.BBX,8/F
+play,7,0,shucj001,22,BBCFS,K
+play,7,0,navad001,30,BBBB,W
+play,7,0,sancc001,22,CSBFF*BS,K
+play,7,1,fowld001,00,,NP
+sub,jonen001,"Nate Jones",0,8,1
+play,7,1,fowld001,00,,NP
+sub,salat001,"Tyler Saladino",0,9,4
+play,7,1,fowld001,00,..X,9/L+
+play,7,1,bryak001,11,BFX,3/P3F
+play,7,1,rizza001,12,FBCS,K
+play,8,0,salat001,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,8,0,salat001,12,.BCFX,D7/L+
+play,8,0,eatoa002,02,FLC,K
+play,8,0,andet001,01,CX,43/G.2-3
+play,8,0,cabrm002,00,,NP
+sub,chapa001,"Aroldis Chapman",1,9,1
+play,8,0,cabrm002,22,.BSTFBS,K
+play,8,1,zobrb001,01,FX,D9/L+.B-3(E9)
+play,8,1,contw001,12,CCF*BX,53/G
+play,8,1,russa002,21,CBBX,63/G.3-H(UR)
+play,8,1,baezj001,00,,NP
+sub,kahnt001,"Tommy Kahnle",0,8,1
+play,8,1,baezj001,32,.CBBSFFFBFB,W
+play,8,1,szczm001,00,,NP
+sub,lastt001,"Tommy La Stella",1,8,11
+play,8,1,lastt001,00,,NP
+sub,jennd003,"Dan Jennings",0,8,1
+play,8,1,lastt001,22,..CFBBFFX,8/F
+play,9,0,abrej003,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,9,0,abrej003,00,,NP
+sub,heywj001,"Jason Heyward",1,8,9
+play,9,0,abrej003,12,..BCFFX,63/G+
+play,9,0,frazt001,22,FSFBBFS,K
+play,9,0,shucj001,00,,NP
+sub,garca003,"Avisail Garcia",0,6,11
+play,9,0,garca003,32,.BBCBTX,43/G
+data,er,salec001,2
+data,er,jonen001,0
+data,er,kahnt001,0
+data,er,jennd003,0
+data,er,lackj001,1
+data,er,strop001,0
+data,er,rondh001,0
+data,er,chapa001,0
+id,CHN201607290
+version,2
+info,visteam,SEA
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/29
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,coope901
+info,ump1b,barrl901
+info,ump2b,iassd901
+info,ump3b,fagac901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,76
+info,winddir,unknown
+info,windspeed,10
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,188
+info,attendance,40951
+info,wp,lestj001
+info,lp,iwakh001
+info,save,
+start,omals001,"Shawn O'Malley",0,1,6
+start,gutif001,"Franklin Gutierrez",0,2,7
+start,canor001,"Robinson Cano",0,3,4
+start,cruzn002,"Nelson Cruz",0,4,9
+start,seagk001,"Kyle Seager",0,5,5
+start,lee-d004,"Dae-Ho Lee",0,6,3
+start,martl004,"Leonys Martin",0,7,8
+start,iannc001,"Chris Iannetta",0,8,2
+start,iwakh001,"Hisashi Iwakuma",0,9,1
+start,coghc001,"Chris Coghlan",1,1,7
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,9
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,8
+start,baezj001,"Javier Baez",1,7,4
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,omals001,12,BCSX,S5/G/MREV
+com,"replay,1,omals001,SEA,iassd901,CHI11,,Y,M,SEA,C"
+com,"$when Shawn O'Malley was called out at 1B, Mariners"
+com,"manager Scott Servais challenged the ruling; the"
+com,"call was overturned by replay"
+play,1,0,gutif001,22,CB+1BS>S,K+SB2
+play,1,0,canor001,31,BBCBB,W
+play,1,0,cruzn002,22,BBCFFS,K
+play,1,0,seagk001,12,BSFS,K
+play,1,1,coghc001,10,BX,13/G-
+play,1,1,bryak001,01,CX,D7/L+
+play,1,1,rizza001,20,BBX,43/G.2-3
+play,1,1,zobrb001,30,BBBB,W
+play,1,1,russa002,10,BX,8/F
+play,2,0,lee-d004,21,FBBX,8/F
+play,2,0,martl004,22,SCBBX,D7/L
+play,2,0,iannc001,21,BBFX,9/F
+play,2,0,iwakh001,01,C>X,63/G
+play,2,1,heywj001,02,CSFX,43/G
+play,2,1,baezj001,00,X,S1/G-
+play,2,1,rossd001,11,BSX,S7/L.1-2
+play,2,1,lestj001,12,BFSX,13/BG/SH.2-3;1-2
+play,2,1,coghc001,32,B*BBCSFX,S8/L.3-H;2-H;B-2(TH)
+play,2,1,bryak001,01,SX,S7/L.2-H
+play,2,1,rizza001,02,1FF1X,5/P
+play,3,0,omals001,22,LBLBT,K
+play,3,0,gutif001,02,CSX,7/L
+play,3,0,canor001,00,X,S8/G+
+play,3,0,cruzn002,31,BBFBB,W.1-2
+play,3,0,seagk001,00,X,7/L
+play,3,1,zobrb001,11,BCX,D7/L
+play,3,1,russa002,12,CLBS,K
+play,3,1,heywj001,21,CBBX,HR/89/L.2-H
+play,3,1,baezj001,11,CBX,S9/G
+play,3,1,rossd001,22,BCBFX,8/F
+play,3,1,lestj001,02,FCFC,K
+play,4,0,lee-d004,22,FBCBS,K
+play,4,0,martl004,12,CSFBFFS,K
+play,4,0,iannc001,22,SBCBC,K
+play,4,1,coghc001,00,,NP
+sub,karnn001,"Nathan Karns",0,9,1
+play,4,1,coghc001,12,.CCFBC,K
+play,4,1,bryak001,11,CBX,S8/G+
+play,4,1,rizza001,21,BBS>S,SB2
+play,4,1,rizza001,22,BBS>S.X,FC5/G.2X3(5656)
+play,4,1,zobrb001,12,C1FB>B,SB2
+play,4,1,zobrb001,22,C1FB>B.X,8/F
+play,5,0,karnn001,11,CBX,53/G
+play,5,0,omals001,10,BX,6/L
+play,5,0,gutif001,22,BCCBX,S8/L+
+play,5,0,canor001,01,C>B,SB2
+play,5,0,canor001,32,C>B.BFBX,8/L+
+play,5,1,russa002,00,X,7/F
+play,5,1,heywj001,32,BCBBCX,7/F
+play,5,1,baezj001,32,CBBBCS,K
+play,6,0,cruzn002,20,BBX,63/G
+play,6,0,seagk001,11,CBX,9/F
+play,6,0,lee-d004,01,FX,9/L+
+play,6,1,rossd001,10,BX,HR/78/F
+play,6,1,lestj001,32,CBBBFB,W
+play,6,1,coghc001,31,BBBCB,W.1-2
+play,6,1,bryak001,32,S*BFFB*BB,W.2-3;1-2
+play,6,1,rizza001,32,BSBCBFX,D7/G.3-H;2-H;1-H
+play,6,1,zobrb001,00,,NP
+sub,nunov001,"Vidal Nuno",0,6,1
+play,6,1,zobrb001,00,,NP
+sub,sardl001,"Luis Sardinas",0,9,3
+play,6,1,zobrb001,01,..CX,S7/L.2-3
+play,6,1,russa002,02,CTFFX,2/P2F
+play,6,1,heywj001,10,BX,7/F7LF/SF.3-H;1-2
+play,6,1,baezj001,12,BSFX,S7/L+.2-H
+play,6,1,rossd001,22,CBSBC,K
+play,7,0,martl004,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,7,0,martl004,32,.CBSBFBX,5/P5F
+play,7,0,iannc001,10,BX,S6/G
+play,7,0,sardl001,00,X,5/P5F
+play,7,0,omals001,00,X,8/F
+com,"$1:14 rain delay"
+play,7,1,grimj002,00,,NP
+sub,hereg002,"Guillermo Heredia",0,4,9
+play,7,1,grimj002,00,,NP
+sub,wilht001,"Tom Wilhelmsen",0,6,1
+play,7,1,grimj002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,7,1,szczm001,12,...FBFX,S4/G
+play,7,1,coghc001,32,*BSSFB*BF*B,W.1-2
+play,7,1,bryak001,32,C*BFBBB,W.2-3;1-2
+play,7,1,rizza001,20,B*BX,36(1)3/GDP.3-H;2-3
+play,7,1,zobrb001,00,,NP
+sub,contw001,"Willson Contreras",1,4,11
+play,7,1,contw001,01,.SX,9/F
+play,8,0,gutif001,00,,NP
+sub,contw001,"Willson Contreras",1,4,2
+play,8,0,gutif001,00,,NP
+sub,heywj001,"Jason Heyward",1,6,9
+play,8,0,gutif001,00,,NP
+sub,montm002,"Mike Montgomery",1,8,1
+play,8,0,gutif001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,8
+play,8,0,gutif001,21,....BBFX,8/F
+play,8,0,canor001,10,BX,S8/G+
+play,8,0,hereg002,12,FCBC,K
+play,8,0,seagk001,00,X,31/G
+play,8,1,russa002,00,,NP
+sub,linda001,"Adam Lind",0,6,3
+play,8,1,russa002,00,,NP
+sub,sardl001,"Luis Sardinas",0,9,1
+play,8,1,russa002,11,..BFX,53/G+
+play,8,1,heywj001,01,CX,13/G-
+play,8,1,baezj001,11,BCX,8/F
+play,9,0,linda001,20,BBX,43/G
+play,9,0,martl004,00,X,S8/L+
+play,9,0,iannc001,32,BBFBFB,W.1-2
+play,9,0,sardl001,12,CBFS,K
+play,9,0,omals001,01,CX,S7/L.2-H;1-2
+play,9,0,gutif001,32,*BCSB*B>B,W.2-3;1-2
+play,9,0,canor001,32,BBFBF>F>X,43/G+
+data,er,iwakh001,5
+data,er,karnn001,5
+data,er,nunov001,1
+data,er,wilht001,1
+data,er,sardl001,0
+data,er,lestj001,0
+data,er,grimj002,0
+data,er,montm002,1
+id,CHN201607300
+version,2
+info,visteam,SEA
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/30
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,barrl901
+info,ump1b,iassd901
+info,ump2b,fagac901
+info,ump3b,coope901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,75
+info,winddir,fromrf
+info,windspeed,12
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,157
+info,attendance,41401
+info,wp,milew001
+info,lp,arrij001
+info,save,cishs001
+start,aokin001,"Nori Aoki",0,1,7
+start,martl004,"Leonys Martin",0,2,8
+start,canor001,"Robinson Cano",0,3,4
+start,cruzn002,"Nelson Cruz",0,4,9
+start,seagk001,"Kyle Seager",0,5,5
+start,linda001,"Adam Lind",0,6,3
+start,zunim001,"Mike Zunino",0,7,2
+start,omals001,"Shawn O'Malley",0,8,6
+start,milew001,"Wade Miley",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,zobrb001,"Ben Zobrist",1,3,7
+start,baezj001,"Javier Baez",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,contw001,"Willson Contreras",1,7,3
+start,montm001,"Miguel Montero",1,8,2
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,aokin001,21,BFBX,43/G
+play,1,0,martl004,12,BSFS,K+WP.B-1
+play,1,0,canor001,00,B,WP.1-2
+play,1,0,canor001,21,B.FBX,13/G
+play,1,0,cruzn002,02,CSX,63/G
+play,1,1,fowld001,02,CCS,K
+play,1,1,bryak001,22,BFCBS,K
+play,1,1,zobrb001,22,CBFBFS,K
+play,2,0,seagk001,01,CX,43/G
+play,2,0,linda001,01,CX,8/F
+play,2,0,zunim001,12,BSFS,K
+play,2,1,baezj001,10,BX,53/G
+play,2,1,russa002,22,CTBBX,3/P3F
+play,2,1,heywj001,02,CFFC,K
+play,3,0,omals001,01,CX,13/G
+play,3,0,milew001,12,CFFBFX,63/G
+play,3,0,aokin001,22,BCBLFX,13/G
+play,3,1,contw001,12,CFFFFBX,43/G
+play,3,1,montm001,00,X,3/G
+play,3,1,arrij001,02,CFC,K
+play,4,0,martl004,02,FFX,S8/L
+play,4,0,canor001,01,1TX,46(1)3/GDP
+play,4,0,cruzn002,12,CCBX,S7/G
+play,4,0,seagk001,30,B*BBB,W.1-2
+play,4,0,linda001,20,BBX,3/G
+play,4,1,fowld001,10,BX,8/F
+play,4,1,bryak001,02,FSX,E5/G
+play,4,1,zobrb001,00,1,PO1(13)
+play,4,1,zobrb001,31,1.BBBCX,53/G
+play,5,0,zunim001,00,X,9/F
+play,5,0,omals001,02,CFC,K
+play,5,0,milew001,22,CFFBFBX,63/G-
+play,5,1,baezj001,02,CFS,K
+play,5,1,russa002,22,FCBBFX,7/L
+play,5,1,heywj001,12,BCCS,K
+play,6,0,aokin001,12,CFBX,7/F
+play,6,0,martl004,00,X,4/P
+play,6,0,canor001,31,CBBBX,63/G
+play,6,1,contw001,11,BCX,9/F
+play,6,1,montm001,22,BFSBX,13/G
+play,6,1,arrij001,12,FSBS,K
+play,7,0,cruzn002,21,CBBX,63/G
+play,7,0,seagk001,22,FFBBC,K
+play,7,0,linda001,32,CSBBBX,6/P
+play,7,1,fowld001,31,BBFBB,W
+play,7,1,bryak001,22,FF*BBX,S8/G.1-2
+play,7,1,zobrb001,00,X,24/BG/SH.2-3;1-2
+play,7,1,baezj001,12,BSCFX,FC6/G/MREV.3-H;2-3
+com,"replay,7,baezj001,CHN,iassd901,CHI11,,Y,M,CHN,A"
+com,"$when Dexter Fowler was called out at HP, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was overturned by replay"
+play,7,1,russa002,02,1F1LS,K
+play,7,1,heywj001,11,C*B1,CSH(132)/MREV
+com,"replay,7,heywj001,CHN,iassd901,CHI11,,Y,M,SEA,A"
+com,"$when Kris Bryant was called safe at HP, Mariners"
+com,"manager Scott Servais challenged the ruling; the"
+com,"call was overturned by replay"
+play,8,0,zunim001,32,CCBBBFB,W
+play,8,0,omals001,00,,NP
+sub,hereg002,"Guillermo Heredia",0,7,12
+play,8,0,omals001,30,B1B.1BB,W.1-2
+play,8,0,milew001,00,,NP
+sub,sardl001,"Luis Sardinas",0,9,11
+play,8,0,sardl001,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,8,0,sardl001,01,..LX,14/BG/SH.2-3;1-2
+play,8,0,aokin001,22,CBFBX,FC5/G/MREV.3XH(52);2-3
+com,"replay,8,aokin001,SEA,iassd901,CHI11,,N,M,SEA,A"
+com,"$when Guillermo Heredia was called out at HP, Mariners"
+com,"manager Scott Servais challenged the ruling; the"
+com,"call was upheld by replay"
+play,8,0,martl004,00,,NP
+sub,chapa001,"Aroldis Chapman",1,9,1
+play,8,0,martl004,11,.SB>X,D8/L.3-H;1-H
+play,8,0,canor001,01,CN,SB3
+play,8,0,canor001,01,CN.B,WP.3-H(NR)
+play,8,0,canor001,12,CN.B.SS,K
+play,8,1,heywj001,00,,NP
+sub,iannc001,"Chris Iannetta",0,7,2
+play,8,1,heywj001,00,,NP
+sub,diaze006,"Edwin Diaz",0,9,1
+play,8,1,heywj001,11,..CBX,S8/L
+play,8,1,contw001,02,SFB,WP.1-2
+play,8,1,contw001,12,SFB.X,5/L
+play,8,1,montm001,31,BBSBB,W
+play,8,1,chapa001,00,,NP
+sub,szczm001,"Matt Szczur",1,8,12
+play,8,1,chapa001,00,,NP
+sub,rizza001,"Anthony Rizzo",1,9,11
+play,8,1,rizza001,22,..BBSCFC,K
+play,8,1,fowld001,02,FSS,K
+play,9,0,cruzn002,00,,NP
+sub,contw001,"Willson Contreras",1,7,2
+play,9,0,cruzn002,00,,NP
+sub,woodt004,"Travis Wood",1,8,1
+play,9,0,cruzn002,00,,NP
+sub,rizza001,"Anthony Rizzo",1,9,3
+play,9,0,cruzn002,22,...CBBSX,S7/L
+play,9,0,seagk001,00,,NP
+sub,gutif001,"Franklin Gutierrez",0,4,12
+play,9,0,seagk001,00,.X,43/G.1-2
+play,9,0,linda001,10,BX,43/G.2-3
+play,9,0,iannc001,22,C*BCBX,E6/TH/G.3-H(UR)
+play,9,0,omals001,00,X,D7/L.1-3
+play,9,0,diaze006,00,,NP
+sub,lee-d004,"Dae-Ho Lee",0,9,11
+play,9,0,lee-d004,30,.IIII,IW
+play,9,0,aokin001,12,BCSX,43/G
+play,9,1,bryak001,00,,NP
+sub,gutif001,"Franklin Gutierrez",0,4,9
+play,9,1,bryak001,00,,NP
+sub,cishs001,"Steve Cishek",0,9,1
+play,9,1,bryak001,32,..CFBBBC,K
+play,9,1,zobrb001,12,CFBX,S8/L
+play,9,1,baezj001,12,CBSS,K
+play,9,1,russa002,00,>C,DI.1-2
+play,9,1,russa002,02,>C.FS,K
+data,er,milew001,1
+data,er,diaze006,0
+data,er,cishs001,0
+data,er,arrij001,2
+data,er,rondh001,0
+data,er,chapa001,1
+data,er,woodt004,0
+id,CHN201607310
+version,2
+info,visteam,SEA
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/07/31
+info,number,0
+info,starttime,7:08PM
+info,daynight,night
+info,usedh,false
+info,umphome,iassd901
+info,ump1b,fagac901
+info,ump2b,coope901
+info,ump3b,barrl901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,speaa701
+info,temp,75
+info,winddir,fromrf
+info,windspeed,9
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,258
+info,attendance,40952
+info,wp,rondh001
+info,lp,martc008
+info,save,
+start,omals001,"Shawn O'Malley",0,1,6
+start,martl004,"Leonys Martin",0,2,8
+start,canor001,"Robinson Cano",0,3,4
+start,cruzn002,"Nelson Cruz",0,4,9
+start,seagk001,"Kyle Seager",0,5,5
+start,gutif001,"Franklin Gutierrez",0,6,7
+start,lee-d004,"Dae-Ho Lee",0,7,3
+start,zunim001,"Mike Zunino",0,8,2
+start,hernf002,"Felix Hernandez",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,contw001,"Willson Contreras",1,7,2
+start,coghc001,"Chris Coghlan",1,8,7
+start,matub001,"Brian Matusz",1,9,1
+play,1,0,omals001,02,CCX,S8/L-
+play,1,0,martl004,00,B,WP.1-2
+play,1,0,martl004,11,B.SX,23/BG/SH.2-3
+play,1,0,canor001,12,FFBC,K
+play,1,0,cruzn002,10,BX,HR/78/F.3-H
+play,1,0,seagk001,11,BCH,HP
+play,1,0,gutif001,32,CB+1CBFB>B,W.1-2
+play,1,0,lee-d004,30,*BBB*B,W.2-3;1-2
+play,1,0,zunim001,00,X,8/F
+play,1,1,fowld001,32,CCBBBFFB,W
+play,1,1,bryak001,32,F*B*BBC*B,W.1-2
+play,1,1,rizza001,32,BBFSBS,K
+play,1,1,zobrb001,12,BCSC,K
+play,1,1,russa002,02,SFFS,K
+play,2,0,hernf002,02,CCX,13/G-
+play,2,0,omals001,11,BCX,43/G
+play,2,0,martl004,02,FCX,S9/L
+play,2,0,canor001,31,BS*B*BX,HR/89/F.1-H
+play,2,0,cruzn002,00,X,63/G
+play,2,1,heywj001,21,BCBX,43/G
+play,2,1,contw001,22,BSSBFX,9/L
+play,2,1,coghc001,02,CFFC,K
+play,3,0,seagk001,00,X,63/G
+play,3,0,gutif001,22,BBFFX,S8/L
+play,3,0,lee-d004,00,X,HR/78/F.1-H
+play,3,0,zunim001,12,BCSX,3/L3F
+play,3,0,hernf002,12,BFFC,K
+play,3,1,matub001,00,,NP
+sub,hammj002,"Jason Hammel",1,9,11
+play,3,1,hammj002,00,.X,53/G
+play,3,1,fowld001,22,BCCBX,E5/G
+play,3,1,bryak001,12,FSFFBFS,K
+play,3,1,rizza001,12,FBFX,7/L
+play,4,0,omals001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,4,0,omals001,32,.BCBBCFS,K
+play,4,0,martl004,02,CSS,K
+play,4,0,canor001,22,SBFBS,K
+play,4,1,zobrb001,01,FX,S8/G
+play,4,1,russa002,02,1CSX,8/L
+play,4,1,heywj001,21,B1CBX,43/G.1-2
+play,4,1,contw001,12,BCSS,K
+play,5,0,cruzn002,22,BBSCS,K
+play,5,0,seagk001,22,CBFBX,31/G
+play,5,0,gutif001,22,BCBCC,K
+play,5,1,coghc001,30,BBBB,W
+play,5,1,edwac001,00,,NP
+sub,montm001,"Miguel Montero",1,9,11
+play,5,1,montm001,11,.BCX,36(1)/FO/G
+play,5,1,fowld001,12,FBSX,S9/L.1-2
+play,5,1,bryak001,32,FBBF*BB,W.2-3;1-2
+play,5,1,rizza001,12,FBSC,K
+play,5,1,zobrb001,30,BBBB,W.3-H;2-3;1-2
+play,5,1,russa002,02,SFH,HP.3-H;2-3;1-2
+play,5,1,heywj001,02,CFS,K
+play,6,0,lee-d004,00,,NP
+sub,nathj001,"Joe Nathan",1,9,1
+play,6,0,lee-d004,32,.FFBBBFB,W
+play,6,0,zunim001,20,BBX,D7/L.1-3
+play,6,0,hernf002,00,,NP
+sub,smits002,"Seth Smith",0,9,11
+play,6,0,smits002,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,6,0,smits002,32,..CBBSFFBB,W
+play,6,0,omals001,12,CF*BS,K
+play,6,0,martl004,22,S*BBFC,K
+play,6,0,canor001,12,C*BFX,6/P
+play,6,1,contw001,00,,NP
+sub,stord001,"Drew Storen",0,9,1
+play,6,1,contw001,01,.FX,63/G
+play,6,1,coghc001,12,CSFFBFFX,43/G
+play,6,1,woodt004,11,BSX,7/F
+play,7,0,cruzn002,00,,NP
+sub,woodt004,"Travis Wood",1,9,7
+play,7,0,cruzn002,00,,NP
+sub,strop001,"Pedro Strop",1,8,1
+play,7,0,cruzn002,00,..X,9/L
+play,7,0,seagk001,21,BBCX,S8/L
+play,7,0,gutif001,00,X,7/L
+play,7,0,lee-d004,22,CB*BCFC,K
+play,7,1,fowld001,00,,NP
+sub,wilht001,"Tom Wilhelmsen",0,9,1
+play,7,1,fowld001,32,.CCBBBB,W
+play,7,1,bryak001,32,FCB*BB>S,K+SB2
+play,7,1,rizza001,21,BC*BX,8/F.2-3
+play,7,1,zobrb001,32,BBCFBFX,T8/L.3-H
+play,7,1,russa002,00,,NP
+sub,diaze006,"Edwin Diaz",0,9,1
+play,7,1,russa002,02,.CCS,K
+play,8,0,zunim001,12,CSBX,D7/G
+play,8,0,diaze006,00,X,FC3/BG.2X3(35)
+play,8,0,omals001,12,FF*BX,46(1)/FO/G
+play,8,0,martl004,00,,NP
+sub,szczm001,"Matt Szczur",1,8,7
+play,8,0,martl004,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,martl004,22,..BSBF11,POCS2(136)
+play,8,1,heywj001,01,SX,63/G
+play,8,1,contw001,01,CX,S18/L
+play,8,1,szczm001,22,FSBBX,S8/L.1-2
+play,8,1,woodt004,00,,NP
+sub,baezj001,"Javier Baez",1,9,11
+play,8,1,baezj001,02,.FCS,K
+play,8,1,fowld001,22,CFFBBC,K
+play,9,0,martl004,00,,NP
+sub,montm002,"Mike Montgomery",1,1,1
+play,9,0,martl004,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,9,0,martl004,00,,NP
+sub,szczm001,"Matt Szczur",1,8,8
+play,9,0,martl004,00,,NP
+sub,baezj001,"Javier Baez",1,9,4
+play,9,0,martl004,02,....CSS,K
+play,9,0,canor001,00,X,1/G
+play,9,0,cruzn002,21,CBBX,S4/G
+play,9,0,seagk001,00,,NP
+sub,hereg002,"Guillermo Heredia",0,4,12
+play,9,0,seagk001,11,.BCX,S8/L.1-2
+play,9,0,gutif001,22,S*BBSS,K
+play,9,1,bryak001,00,,NP
+sub,hereg002,"Guillermo Heredia",0,4,7
+play,9,1,bryak001,00,,NP
+sub,gutif001,"Franklin Gutierrez",0,6,9
+play,9,1,bryak001,00,,NP
+sub,cishs001,"Steve Cishek",0,9,1
+play,9,1,bryak001,22,...BBCSS,K
+play,9,1,rizza001,32,BBBCFX,D9/L
+play,9,1,zobrb001,32,BBCBCX,S7/L.2-3
+play,9,1,russa002,01,CX,S7/L.3-H;1-3;B-2(TH)
+play,9,1,heywj001,00,H,HP
+play,9,1,contw001,12,CBCX,54(1)/FO/G/MREV.3-H;2-3
+com,"replay,9,contw001,CHN,iassd901,CHI11,,N,M,SEA,C"
+com,"$when Willson Contreras was called safe at 1B, Mariners"
+com,"manager Scott Servais challenged the ruling; the call"
+com,"was upheld by replay"
+play,9,1,szczm001,02,FFB,WP.3-H(NR);1-2
+play,9,1,szczm001,12,FFB.FFX,9/F
+play,10,0,lee-d004,00,,NP
+sub,rossd001,"David Ross",1,1,2
+play,10,0,lee-d004,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,9
+play,10,0,lee-d004,00,,NP
+sub,heywj001,"Jason Heyward",1,6,8
+play,10,0,lee-d004,00,,NP
+sub,contw001,"Willson Contreras",1,7,7
+play,10,0,lee-d004,00,,NP
+sub,chapa001,"Aroldis Chapman",1,8,1
+play,10,0,lee-d004,00,.....X,63/G
+play,10,0,zunim001,22,BSBFC,K
+play,10,0,cishs001,00,,NP
+sub,aokin001,"Nori Aoki",0,9,11
+play,10,0,aokin001,12,.FBCX,13/G
+play,10,1,baezj001,00,,NP
+sub,martc008,"Cody Martin",0,9,1
+play,10,1,baezj001,12,.CBFS,K
+play,10,1,rossd001,32,BCFFBBS,K
+play,10,1,bryak001,01,FX,43/G
+play,11,0,omals001,00,,NP
+sub,rondh001,"Hector Rondon",1,8,1
+play,11,0,omals001,02,.CSX,53/G
+play,11,0,martl004,11,FBX,3/G
+play,11,0,canor001,22,BFSBFFX,7/F7LF
+play,11,1,rizza001,02,CCX,7/F
+play,11,1,zobrb001,21,CBBX,7/L
+play,11,1,russa002,12,FFBC,K
+play,12,0,hereg002,22,FFBBX,63/G
+play,12,0,seagk001,22,CBBCX,13/G
+play,12,0,gutif001,12,SBCS,K
+play,12,1,heywj001,02,CCX,D8/L
+play,12,1,contw001,00,X,8/F.2-3
+play,12,1,rondh001,00,,NP
+sub,lestj001,"Jon Lester",1,8,11
+play,12,1,lestj001,22,.*BCPFX,FC1/BG/SH.3-H
+data,er,hernf002,2
+data,er,stord001,0
+data,er,wilht001,1
+data,er,diaze006,0
+data,er,cishs001,3
+data,er,martc008,1
+data,er,matub001,6
+data,er,edwac001,0
+data,er,nathj001,0
+data,er,woodt004,0
+data,er,strop001,0
+data,er,montm002,0
+data,er,chapa001,0
+data,er,rondh001,0
+id,CHN201608010
+version,2
+info,visteam,MIA
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/01
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,wegnm901
+info,ump1b,muchm901
+info,ump2b,fostm901
+info,ump3b,wintm901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,77
+info,winddir,rtol
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,167
+info,attendance,40937
+info,wp,hendk001
+info,lp,conla001
+info,save,
+start,gordd002,"Dee Gordon",0,1,4
+start,pradm001,"Martin Prado",0,2,5
+start,yelic001,"Christian Yelich",0,3,7
+start,stanm004,"Giancarlo Stanton",0,4,9
+start,ozunm001,"Marcell Ozuna",0,5,8
+start,realj001,"J.T. Realmuto",0,6,2
+start,dietd001,"Derek Dietrich",0,7,3
+start,hecha001,"Adeiny Hechavarria",0,8,6
+start,conla001,"Adam Conley",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,baezj001,"Javier Baez",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,contw001,"Willson Contreras",1,7,2
+start,szczm001,"Matt Szczur",1,8,7
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,gordd002,01,FX,8/F
+play,1,0,pradm001,32,CBBFBX,9/L
+play,1,0,yelic001,32,CBBFBX,43/G-
+play,1,1,fowld001,32,CCFBFBBB,W
+play,1,1,bryak001,22,BSB11CX,7/F
+play,1,1,rizza001,02,CF1X,DGR/9/L+.1-3
+play,1,1,baezj001,00,X,3/P3F
+play,1,1,russa002,22,BF*BFX,S9/L.3-H;2-H
+play,1,1,heywj001,12,FS1BX,S7/G.1-2
+play,1,1,contw001,31,CB*BBB,W.2-3;1-2
+play,1,1,szczm001,12,SF*BFS,K
+play,2,0,stanm004,12,CFBC,K
+play,2,0,ozunm001,00,X,S8/L
+play,2,0,realj001,21,BCB1X,S76/L-.1-2
+play,2,0,dietd001,11,BCX,31/G/MREV.2-3;1-2
+com,"replay,2,dietd001,MIA,wintm901,CHI11,,N,M,MIA,C"
+com,"$when Derek Dietrich was called out at 1B, Marlins"
+com,"manager Don Mattingly challenged the ruling; the"
+com,"call was upheld by replay"
+play,2,0,hecha001,30,IIII,IW
+play,2,0,conla001,02,CFX,63/G-
+play,2,1,hendk001,32,BBBCCB,W
+play,2,1,fowld001,32,BFS*BFBB,W.1-2
+play,2,1,bryak001,21,C*BBX,54(1)3/GDP.2-3
+play,2,1,rizza001,31,BCBBB,W
+play,2,1,baezj001,32,BCFB*B>F>S,K
+play,3,0,gordd002,12,CBSS,K
+play,3,0,pradm001,01,CX,S9/G
+play,3,0,yelic001,22,FBBSC,K
+play,3,0,stanm004,32,T*BS1BB>F>F>B,W.1-2
+play,3,0,ozunm001,10,B2,PO2(E4).2-3;1-2
+play,3,0,ozunm001,10,B2.X,53/G
+play,3,1,russa002,10,BX,8/F
+play,3,1,heywj001,32,BCFBBX,9/L
+play,3,1,contw001,10,BX,D7/L+
+play,3,1,szczm001,30,IIII,IW
+play,3,1,hendk001,12,CFBS,K
+play,4,0,realj001,31,FBBBX,53/G
+play,4,0,dietd001,10,BX,D9/L.BX3(945)
+play,4,0,hecha001,02,CCX,63/G
+play,4,1,fowld001,00,X,S5/G-
+play,4,1,bryak001,00,X,9/F
+play,4,1,rizza001,01,CH,HP.1-2
+play,4,1,baezj001,32,*BCBBTC,K
+play,4,1,russa002,21,CBBX,6/P
+play,5,0,conla001,00,,NP
+sub,johnc003,"Chris Johnson",0,9,11
+play,5,0,johnc003,12,.CCBFX,7/L
+play,5,0,gordd002,11,BCX,S8/G
+play,5,0,pradm001,10,B+11>B,CS2(24)
+play,5,0,pradm001,31,B+11>B.SBX,43/G-
+play,5,1,heywj001,00,,NP
+sub,mcgod001,"Dustin McGowan",0,9,1
+play,5,1,heywj001,32,.CBBFBS,K
+play,5,1,contw001,31,BCBBB,W
+play,5,1,szczm001,11,CBX,S9/L.1-3
+play,5,1,hendk001,00,>B,SB2
+play,5,1,hendk001,10,>B.X,S7/G.3-H;2-3
+play,5,1,fowld001,10,BX,8/F/SF.3-H
+play,5,1,bryak001,32,*BBFBF>X,4/L-
+play,6,0,yelic001,11,BFX,S8/L+
+play,6,0,stanm004,22,BSBSC,K
+play,6,0,ozunm001,00,X,4/P
+play,6,0,realj001,02,CFX,63/G/MREV
+com,"replay,6,realj001,MIA,wintm901,CHI11,,Y,M,CHN,C"
+com,"$when J.T. Realmuto was called safe at 1B, Cubs"
+com,"manager Joe Maddon challenged the ruling; the call"
+com,"was overturned by replay"
+play,6,1,rizza001,10,BX,T9/F
+play,6,1,baezj001,00,X,7/L+/SF.3-H
+play,6,1,russa002,12,SBSS,K
+play,6,1,heywj001,11,BSX,D9/L+
+play,6,1,contw001,00,X,6/P
+play,7,0,dietd001,02,CFFT,K
+play,7,0,hecha001,00,X,S7/G
+play,7,0,mcgod001,00,,NP
+sub,suzui001,"Ichiro Suzuki",0,9,11
+play,7,0,suzui001,10,.BX,5/L/DP/MREV.1X1(53)
+com,"replay,7,suzui001,MIA,wintm901,CHI11,,Y,M,CHN,C"
+com,"$when Adeiny Hechavarria was called safe at 1B, Cubs"
+com,"manager Joe Maddon challenged the ruling; the call"
+com,"was overturned by replay"
+play,7,1,szczm001,00,,NP
+sub,ogann001,"Nefi Ogando",0,9,1
+play,7,1,szczm001,32,.FFBFBFBS,K
+play,7,1,hendk001,22,BSSBX,9/L
+play,7,1,fowld001,22,CSBBX,13/G-
+play,8,0,gordd002,01,CX,7/F
+play,8,0,pradm001,22,CFBBX,8/F
+play,8,0,yelic001,22,CBSBX,43/G
+play,8,1,bryak001,00,,NP
+sub,rojam002,"Miguel Rojas",0,2,5
+play,8,1,bryak001,00,.X,31/G
+play,8,1,rizza001,21,BBFX,S9/G
+play,8,1,baezj001,21,BF*BX,4/L-
+play,8,1,russa002,12,FBSX,7/L+
+play,9,0,stanm004,02,SSFX,9/L+
+play,9,0,ozunm001,31,CBBBB,W
+play,9,0,realj001,22,FFBFBX,64(1)3/GDP
+data,er,conla001,2
+data,er,mcgod001,3
+data,er,ogann001,0
+data,er,hendk001,0
+id,CHN201608020
+version,2
+info,visteam,MIA
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/02
+info,number,0
+info,starttime,7:07PM
+info,daynight,night
+info,usedh,false
+info,umphome,muchm901
+info,ump1b,fostm901
+info,ump2b,wintm901
+info,ump3b,wegnm901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,81
+info,winddir,unknown
+info,windspeed,1
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,168
+info,attendance,40419
+info,wp,hammj002
+info,lp,fernj003
+info,save,chapa001
+start,realj001,"J.T. Realmuto",0,1,2
+start,pradm001,"Martin Prado",0,2,5
+start,yelic001,"Christian Yelich",0,3,7
+start,stanm004,"Giancarlo Stanton",0,4,9
+start,ozunm001,"Marcell Ozuna",0,5,8
+start,dietd001,"Derek Dietrich",0,6,4
+start,johnc003,"Chris Johnson",0,7,3
+start,hecha001,"Adeiny Hechavarria",0,8,6
+start,fernj003,"Jose Fernandez",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,contw001,"Willson Contreras",1,2,2
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,heywj001,"Jason Heyward",1,5,9
+start,russa002,"Addison Russell",1,6,6
+start,coghc001,"Chris Coghlan",1,7,7
+start,baezj001,"Javier Baez",1,8,5
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,realj001,22,CBSFBT,K
+play,1,0,pradm001,12,CSBX,S8/L
+play,1,0,yelic001,00,X,7/L
+play,1,0,stanm004,00,X,S7/L+.1-2
+play,1,0,ozunm001,31,*BBBCB,W.2-3;1-2
+play,1,0,dietd001,22,FFBBX,31/G-
+play,1,1,fowld001,01,CX,T9/L
+play,1,1,contw001,10,BX,S6/G.3-H
+play,1,1,rizza001,32,CBBBSC,K
+play,1,1,zobrb001,11,CBX,64(1)3/GDP
+play,2,0,johnc003,02,CCX,53/G
+play,2,0,hecha001,10,BX,8/L
+play,2,0,fernj003,01,CX,53/G-
+play,2,1,heywj001,10,BX,8/F
+play,2,1,russa002,00,X,S9/L
+play,2,1,coghc001,31,B1BCBX,7/F
+play,2,1,baezj001,02,CCX,8/L+
+play,3,0,realj001,02,CCX,63/G+
+play,3,0,pradm001,02,CFFT,K
+play,3,0,yelic001,31,BBCBX,S7/G+
+play,3,0,stanm004,00,111X,9/F
+play,3,1,hammj002,02,CSFC,K
+play,3,1,fowld001,12,CBCX,S8/L+
+play,3,1,contw001,10,B1>S,SB2
+play,3,1,contw001,11,B1>S.X,S7/L.2-3
+play,3,1,rizza001,00,X,7/F-/NDP.3-H(TH)(NR);1X2(14)
+play,4,0,ozunm001,22,CFBBX,63/G-
+play,4,0,dietd001,30,BBBB,W
+play,4,0,johnc003,11,B+1CX,46(1)3/GDP
+play,4,1,zobrb001,11,BCX,43/G
+play,4,1,heywj001,22,BCBSX,43/G
+play,4,1,russa002,22,BCBCS,K
+play,5,0,hecha001,01,CX,8/L
+play,5,0,fernj003,32,CBBSFBX,53/G
+play,5,0,realj001,32,BCBCBFS,K
+play,5,1,coghc001,22,CBSBX,S8/G
+play,5,1,baezj001,11,*BFN,BK.1-2
+play,5,1,baezj001,12,*BFN.SS,K
+play,5,1,hammj002,00,X,63/G+
+play,5,1,fowld001,32,SBBC*BX,S9/G+.2-H
+play,5,1,contw001,32,S*BBBS>F>B,W.1-2
+play,5,1,rizza001,31,BBFBB,W.2-3;1-2
+play,5,1,zobrb001,12,BTSFS,K
+play,6,0,pradm001,22,BBCCX,4/P
+play,6,0,yelic001,00,X,3/G-
+play,6,0,stanm004,01,CX,S8/L
+play,6,0,ozunm001,01,FX,46(1)/FO/G
+play,6,1,heywj001,12,CBTX,S8/G+
+play,6,1,russa002,12,BSCH,HP.1-2
+play,6,1,coghc001,32,C*BBBSS,K
+play,6,1,baezj001,02,SFS,K
+play,6,1,hammj002,00,,NP
+sub,montm001,"Miguel Montero",1,9,11
+play,6,1,montm001,12,.BFFS,K
+play,7,0,dietd001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,7,0,dietd001,22,.BSBFX,S9/L
+play,7,0,johnc003,01,SX,E1/TH/FO/G.1-3
+play,7,0,hecha001,21,*BCBX,S7/G.3-H(UR);1-2
+play,7,0,fernj003,00,,NP
+sub,suzui001,"Ichiro Suzuki",0,9,11
+play,7,0,suzui001,12,.BCSS,K
+play,7,0,realj001,02,CSX,S19/G.2-H;1-2
+play,7,0,pradm001,22,*BSCFBS,K
+play,7,0,yelic001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,7,0,yelic001,22,.CCFBBFX,7/L
+play,7,1,fowld001,00,,NP
+sub,barrk002,"Kyle Barraclough",0,9,1
+play,7,1,fowld001,21,.BCBX,43/G
+play,7,1,contw001,20,BBX,8/F
+play,7,1,rizza001,32,BBSFBFB,W
+play,7,1,zobrb001,00,X,3/G
+play,8,0,stanm004,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,8,0,stanm004,22,.BSSBS,K
+play,8,0,ozunm001,12,CCBX,S9/L+
+play,8,0,dietd001,00,,NP
+sub,gordd002,"Dee Gordon",0,5,12
+play,8,0,dietd001,11,.F1B11,PO1(13)/MREV
+com,"replay,8,dietd001,MIA,wintm901,CHI11,,N,M,MIA,A"
+com,"$when Dee Gordon was called out at 1B, Marlins"
+com,"manager Don Mattingly challenged the ruling; the"
+com,"call was upheld by replay"
+play,8,0,dietd001,21,.F1B11.BX,S9/L
+play,8,0,johnc003,01,CX,7/L+
+play,8,1,heywj001,00,,NP
+sub,yelic001,"Christian Yelich",0,3,8
+play,8,1,heywj001,00,,NP
+sub,gordd002,"Dee Gordon",0,5,4
+play,8,1,heywj001,00,,NP
+sub,dietd001,"Derek Dietrich",0,6,7
+play,8,1,heywj001,00,,NP
+sub,dunnm002,"Michael Dunn",0,9,1
+play,8,1,heywj001,32,....BCFBBX,8/F
+play,8,1,russa002,12,CSBS,K
+play,8,1,coghc001,00,,NP
+sub,szczm001,"Matt Szczur",1,7,11
+play,8,1,szczm001,01,.SX,S7/G
+play,8,1,baezj001,00,,NP
+sub,wittn001,"Nick Wittgren",0,9,1
+play,8,1,baezj001,12,.1SCBS,K
+play,9,0,hecha001,00,,NP
+sub,szczm001,"Matt Szczur",1,7,7
+play,9,0,hecha001,00,,NP
+sub,chapa001,"Aroldis Chapman",1,9,1
+play,9,0,hecha001,10,..BX,53/G-
+play,9,0,wittn001,00,,NP
+sub,mathj001,"Jeff Mathis",0,9,11
+play,9,0,mathj001,12,.BCSFT,K
+play,9,0,realj001,22,BFSFFBFX,53/G
+data,er,fernj003,3
+data,er,barrk002,0
+data,er,dunnm002,0
+data,er,wittn001,0
+data,er,hammj002,0
+data,er,strop001,1
+data,er,woodt004,0
+data,er,rondh001,0
+data,er,chapa001,0
+id,CHN201608030
+version,2
+info,visteam,MIA
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/03
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,fostm901
+info,ump1b,wintm901
+info,ump2b,wegnm901
+info,ump3b,muchm901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,88
+info,winddir,fromrf
+info,windspeed,15
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,199
+info,attendance,41147
+info,wp,grimj002
+info,lp,ramoa001
+info,save,
+start,gordd002,"Dee Gordon",0,1,4
+start,pradm001,"Martin Prado",0,2,5
+start,yelic001,"Christian Yelich",0,3,7
+start,stanm004,"Giancarlo Stanton",0,4,9
+start,ozunm001,"Marcell Ozuna",0,5,8
+start,dietd001,"Derek Dietrich",0,6,3
+start,mathj001,"Jeff Mathis",0,7,2
+start,hecha001,"Adeiny Hechavarria",0,8,6
+start,koeht001,"Tom Koehler",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,contw001,"Willson Contreras",1,5,7
+start,heywj001,"Jason Heyward",1,6,9
+start,montm001,"Miguel Montero",1,7,2
+start,baezj001,"Javier Baez",1,8,6
+start,lackj001,"John Lackey",1,9,1
+play,1,0,gordd002,11,CBX,S6/G
+play,1,0,pradm001,00,>C,SB2
+play,1,0,pradm001,02,>C.FFX,4/L-
+play,1,0,yelic001,00,X,D7/L+.2-H
+play,1,0,stanm004,02,CFS,K
+play,1,0,ozunm001,12,FSBS,K
+play,1,1,fowld001,21,CBBX,31/G
+play,1,1,bryak001,32,BBBCFB,W
+play,1,1,rizza001,12,BCCFX,7/L
+play,1,1,zobrb001,22,1BBCC>X,S9/L.1-3
+play,1,1,contw001,21,CBBX,54(1)/FO/G
+play,2,0,dietd001,22,BBCFX,3/L
+play,2,0,mathj001,00,X,5/P
+play,2,0,hecha001,02,CSX,63/G
+play,2,1,heywj001,21,CBBX,6/P
+play,2,1,montm001,10,BX,8/F
+play,2,1,baezj001,32,BBSCBX,9/F-
+play,3,0,koeht001,02,CSFC,K
+play,3,0,gordd002,10,BX,S1/BG
+play,3,0,pradm001,01,C111X,46(1)3/GDP
+play,3,1,lackj001,00,X,D8/L
+play,3,1,fowld001,30,B*BBX,7/L
+play,3,1,bryak001,12,CS*BS,K
+play,3,1,rizza001,11,BFS,WP.2-3
+play,3,1,rizza001,12,BFS.C,K
+play,4,0,yelic001,32,BCBBCX,S7/G
+play,4,0,stanm004,21,BBFX,8/F
+play,4,0,ozunm001,32,SC11BBBX,7/F
+play,4,0,dietd001,00,X,S3/P-.1-2
+play,4,0,mathj001,00,X,8/F
+play,4,1,zobrb001,21,CBBX,8/F
+play,4,1,contw001,31,CBBBX,53/G
+play,4,1,heywj001,02,CFC,K
+play,5,0,hecha001,00,X,13/BG
+play,5,0,koeht001,12,CSBS,K
+play,5,0,gordd002,02,CFFFFS,K
+play,5,1,montm001,22,CSBFBS,K
+play,5,1,baezj001,12,CFBFFS,K
+play,5,1,lackj001,11,FBX,D7/L
+play,5,1,fowld001,12,CC*BFS,K
+play,6,0,pradm001,12,CCBS,K
+play,6,0,yelic001,32,BCSBBFX,43/G
+play,6,0,stanm004,00,X,7/L+
+play,6,1,bryak001,22,BSBSF,FLE2
+play,6,1,bryak001,22,BSBSFC,K
+play,6,1,rizza001,11,SBX,S9/L
+play,6,1,zobrb001,02,FFFB,WP.1-2
+play,6,1,zobrb001,22,FFFB.BX,43/G.2-3
+play,6,1,contw001,00,X,S8/G.3-H
+play,6,1,heywj001,12,BCF*B,SB2
+play,6,1,heywj001,32,BCF*B.BX,3/L+
+play,7,0,ozunm001,22,CFBBS,K
+play,7,0,dietd001,31,BBBCH,HP
+play,7,0,mathj001,01,CX,HR/78/L.1-H
+play,7,0,hecha001,10,BX,S7/L
+play,7,0,koeht001,00,,NP
+sub,suzui001,"Ichiro Suzuki",0,9,11
+play,7,0,suzui001,01,.FX,6/L-
+play,7,0,gordd002,02,SFF>B,SB2
+play,7,0,gordd002,22,SFF>B.*BS,K
+play,7,1,montm001,00,,NP
+sub,rojam002,"Miguel Rojas",0,6,3
+play,7,1,montm001,00,,NP
+sub,barrk002,"Kyle Barraclough",0,9,1
+play,7,1,montm001,12,..CSBX,7/F
+play,7,1,baezj001,22,CSBBS,K
+play,7,1,lackj001,00,,NP
+sub,coghc001,"Chris Coghlan",1,9,11
+play,7,1,coghc001,12,.SBCS,K
+play,8,0,pradm001,00,,NP
+sub,smitj002,"Joe Smith",1,9,1
+play,8,0,pradm001,22,.CCBBFX,7/F
+play,8,0,yelic001,20,BBX,HR/89/L
+play,8,0,stanm004,22,CBFBFFX,9/F
+play,8,0,ozunm001,21,CBBX,S8/L-
+play,8,0,rojam002,00,X,S6/G.1-2
+play,8,0,mathj001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,8,0,mathj001,12,.BCFS,K
+play,8,1,fowld001,00,,NP
+sub,rodnf001,"Fernando Rodney",0,9,1
+play,8,1,fowld001,31,.BBBCX,S9/G
+play,8,1,bryak001,00,X,S7/L.1-3
+play,8,1,rizza001,31,BBCBB,W+WP.3-H(NR);1-2
+play,8,1,zobrb001,32,SL*BBBX,34/BG/SH.2-3;1-2
+play,8,1,contw001,12,BCCS,K
+play,8,1,heywj001,32,CB*BBCX,63/G
+play,9,0,hecha001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,9,0,hecha001,32,.BFSBBX,63/G
+play,9,0,rodnf001,00,,NP
+sub,johnc003,"Chris Johnson",0,9,11
+play,9,0,johnc003,22,.SBBFFFS,K
+play,9,0,gordd002,22,BBCCX,S6/G
+play,9,0,pradm001,20,BB111>B,SB2
+play,9,0,pradm001,30,BB111>B.B,W
+play,9,0,yelic001,10,BB,WP.2-3;1-2
+play,9,0,yelic001,22,BB.CCFS,K
+play,9,1,montm001,00,,NP
+sub,ramoa001,"A.J. Ramos",0,9,1
+play,9,1,montm001,00,.X,D9/L
+play,9,1,baezj001,31,*BBCBX,S7/G.2-3
+play,9,1,grimj002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,9,1,szczm001,31,.BBBCB,W.1-2
+play,9,1,fowld001,32,SBBCBX,9/F/SF.3-H;2-3;1-2
+play,9,1,bryak001,32,STBBBFC,K
+play,9,1,rizza001,30,IIII,IW
+play,9,1,zobrb001,31,BBBCB,W.3-H;2-3;1-2
+play,9,1,contw001,01,CB,WP.3-H(NR);2-3;1-2
+data,er,koeht001,1
+data,er,barrk002,0
+data,er,rodnf001,1
+data,er,ramoa001,3
+data,er,lackj001,3
+data,er,smitj002,1
+data,er,edwac001,0
+data,er,grimj002,0
+id,CHN201608090
+version,2
+info,visteam,ANA
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/09
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,gibsh902
+info,ump1b,wendh902
+info,ump2b,laynj901
+info,ump3b,sches901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,82
+info,winddir,rtol
+info,windspeed,3
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,142
+info,attendance,41227
+info,wp,lackj001
+info,lp,weavj003
+info,save,
+start,escoy001,"Yunel Escobar",0,1,5
+start,calhk001,"Kole Calhoun",0,2,9
+start,troum001,"Mike Trout",0,3,8
+start,pujoa001,"Albert Pujols",0,4,3
+start,simma001,"Andrelton Simmons",0,5,6
+start,choij001,"Ji-Man Choi",0,6,7
+start,bandj001,"Jett Bandy",0,7,2
+start,weavj003,"Jered Weaver",0,8,1
+start,pennc001,"Cliff Pennington",0,9,4
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,solej001,"Jorge Soler",1,5,7
+start,heywj001,"Jason Heyward",1,6,9
+start,russa002,"Addison Russell",1,7,6
+start,contw001,"Willson Contreras",1,8,2
+start,lackj001,"John Lackey",1,9,1
+play,1,0,escoy001,00,X,9/L
+play,1,0,calhk001,10,BX,HR/78/F
+play,1,0,troum001,32,BFTBBX,8/L
+play,1,0,pujoa001,21,CBBX,8/F
+play,1,1,fowld001,11,BCX,8/L
+play,1,1,bryak001,00,X,3/P
+play,1,1,rizza001,32,SBSBFB*B,W
+play,1,1,zobrb001,00,>C,CS2(26)
+play,2,0,simma001,22,FBBSFX,3/G
+play,2,0,choij001,22,FBFBFC,K
+play,2,0,bandj001,22,BSBFFC,K
+play,2,1,zobrb001,32,CBBBCFT,K
+play,2,1,solej001,22,CCBBX,63/G
+play,2,1,heywj001,02,CSX,S8/L
+play,2,1,russa002,02,CSS,K
+play,3,0,weavj003,02,FSC,K
+play,3,0,pennc001,02,CSC,K
+play,3,0,escoy001,22,SFBBX,63/G+
+play,3,1,contw001,22,SSBBX,HR/78/L
+play,3,1,lackj001,01,CX,8/F
+play,3,1,fowld001,01,CX,53/G-
+play,3,1,bryak001,12,FFBX,9/F
+play,4,0,calhk001,11,BCX,63/G
+play,4,0,troum001,12,SBSC,K
+play,4,0,pujoa001,30,BBBX,9/F
+play,4,1,rizza001,10,BX,D9/L+
+play,4,1,zobrb001,32,BBFBSX,D9/L.2-H
+play,4,1,solej001,00,X,S7/L.2-3
+play,4,1,heywj001,22,BCTBX,4/P
+play,4,1,russa002,22,SSBB1X,8/F/SF.3-H
+play,4,1,contw001,12,CSBX,4/L
+play,5,0,simma001,32,CBBCFFBX,63/G+
+play,5,0,choij001,00,X,S6/G/MREV
+com,"replay,5,choij001,ANA,laynj901,CHI11,,Y,M,ANA,C"
+com,"$when Ji-Man Choi was called out at 1B, Angels"
+com,"manager Mike Scioscia challenged the ruling; the"
+com,"call was overturned by replay"
+play,5,0,bandj001,00,X,7/L
+play,5,0,weavj003,12,FC+1BFX,43/G-
+play,5,1,lackj001,10,BX,63/G
+play,5,1,fowld001,00,X,5/P5F/FINT
+com,"$two fans reached out on Dexter Fowler's popup behind"
+com,"3B; the fans did not touch the ball and it was ruled not"
+com,"to be fan interference; Angels manager Mike Scioscia"
+com,"talked with 3B umpire Stu Scheurwater and crew chief"
+com,"Jerry Layne; the umpires huddled and overturned the"
+com,"call to interference and an out since the fans seemed"
+com,"to impede Yunel Escobar"
+play,5,1,bryak001,00,X,HR/7/F
+play,5,1,rizza001,21,CBBX,D6/P
+play,5,1,zobrb001,31,BBCBB,W
+play,5,1,solej001,11,BSX,S3/G-.2-H(E1)(UR)(NR);1-3
+play,5,1,heywj001,22,BCS*BS,K
+play,6,0,pennc001,31,BBBCB,W
+play,6,0,escoy001,01,CX,9/L
+play,6,0,calhk001,11,SB*B,OA.1X2(26)
+play,6,0,calhk001,21,SB*B.X,S9/G
+play,6,0,troum001,11,*BCX,8/L
+play,6,1,russa002,00,,NP
+sub,morim002,"Mike Morin",0,8,1
+play,6,1,russa002,12,.SSFBC,K
+play,6,1,contw001,22,CBBSX,13/G
+play,6,1,lackj001,02,CFC,K
+play,7,0,pujoa001,02,CSX,9/L
+play,7,0,simma001,01,MX,63/G
+play,7,0,choij001,20,BBX,3/G-
+play,7,1,fowld001,00,,NP
+sub,salaf001,"Fernando Salas",0,8,1
+play,7,1,fowld001,12,.BSSX,43/G
+play,7,1,bryak001,12,FBCFS,K
+play,7,1,rizza001,22,FBCBS,K
+play,8,0,bandj001,32,BBBCFC,K
+play,8,0,salaf001,00,,NP
+sub,giavj001,"Johnny Giavotella",0,8,11
+play,8,0,giavj001,02,.CSFX,9/F
+play,8,0,pennc001,10,BX,8/L
+play,8,1,zobrb001,00,,NP
+sub,achta001,"A.J. Achter",0,8,1
+play,8,1,zobrb001,02,.CFX,43/G
+play,8,1,solej001,22,SSBBFX,3/G
+play,8,1,heywj001,00,X,43/G
+play,9,0,escoy001,00,,NP
+sub,bryak001,"Kris Bryant",1,2,7
+play,9,0,escoy001,00,,NP
+sub,strop001,"Pedro Strop",1,5,1
+play,9,0,escoy001,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,9,0,escoy001,01,...SX,31/G-
+play,9,0,calhk001,32,BFBSBX,43/G
+play,9,0,troum001,12,BCFC,K
+data,er,weavj003,4
+data,er,morim002,0
+data,er,salaf001,0
+data,er,achta001,0
+data,er,lackj001,1
+data,er,strop001,0
+id,CHN201608100
+version,2
+info,visteam,ANA
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/10
+info,number,0
+info,starttime,7:05PM
+info,daynight,night
+info,usedh,false
+info,umphome,wendh902
+info,ump1b,laynj901
+info,ump2b,sches901
+info,ump3b,gibsh902
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,84
+info,winddir,fromrf
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,170
+info,attendance,41015
+info,wp,hammj002
+info,lp,nolar001
+info,save,chapa001
+start,escoy001,"Yunel Escobar",0,1,5
+start,calhk001,"Kole Calhoun",0,2,9
+start,troum001,"Mike Trout",0,3,8
+start,pujoa001,"Albert Pujols",0,4,3
+start,simma001,"Andrelton Simmons",0,5,6
+start,choij001,"Ji-Man Choi",0,6,7
+start,sotog001,"Geovany Soto",0,7,2
+start,nolar001,"Ricky Nolasco",0,8,1
+start,petig001,"Gregorio Petit",0,9,4
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,7
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,contw001,"Willson Contreras",1,7,2
+start,baezj001,"Javier Baez",1,8,5
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,escoy001,01,FX,53/G
+play,1,0,calhk001,22,CBCBX,53/G
+play,1,0,troum001,10,BX,8/F
+play,1,1,fowld001,22,FBCBX,S9/L-
+play,1,1,bryak001,32,BS1BFB1FS,K
+play,1,1,rizza001,22,BCB+1FX,9/F
+play,1,1,zobrb001,32,1CSB>FB*B>B,W.1-2
+play,1,1,russa002,21,BFBX,8/F
+play,2,0,pujoa001,32,BBCFBFX,53/G+
+play,2,0,simma001,11,TBX,9/F
+play,2,0,choij001,21,BCBX,31/G
+play,2,1,heywj001,10,BX,9/L
+play,2,1,contw001,22,BCBSFX,9/L
+play,2,1,baezj001,12,CBCS,K
+play,3,0,sotog001,02,CCX,43/G+
+play,3,0,nolar001,30,BBBB,W
+play,3,0,petig001,12,CBFFS,K
+play,3,0,escoy001,30,BBBX,S7/G.1-2
+play,3,0,calhk001,00,X,43/G+
+play,3,1,hammj002,12,SBFS,K
+play,3,1,fowld001,02,CFC,K
+play,3,1,bryak001,22,SBFBX,D7/L
+play,3,1,rizza001,22,CS*B*BX,S4/G.2-H
+play,3,1,zobrb001,21,BCBX,3/G
+play,4,0,troum001,32,CBBCBX,S6/G
+play,4,0,pujoa001,02,C1FC,K
+play,4,0,simma001,01,11FX,S9/L.1-2
+play,4,0,choij001,11,CBX,7/F7LF
+play,4,0,sotog001,31,SBBB>C,SB3;SB2
+play,4,0,sotog001,32,SBBB>C.FB,W
+play,4,0,nolar001,11,CBX,23/G-
+play,4,1,russa002,11,FBX,13/G
+play,4,1,heywj001,12,CSBX,3/G
+play,4,1,contw001,00,X,9/F
+play,5,0,petig001,12,SSBX,63/G
+play,5,0,escoy001,01,CX,S8/G
+play,5,0,calhk001,02,1CCS,K
+play,5,0,troum001,12,1C+1FFBC,K
+play,5,1,baezj001,02,CFX,8/F
+play,5,1,hammj002,00,X,S9/L-
+play,5,1,fowld001,10,BB,WP.1-2
+play,5,1,fowld001,20,BB.X,D7/G.2-H
+play,5,1,bryak001,31,FB*BBX,8/F.2-3
+play,5,1,rizza001,22,C*BBFX,8/F
+play,6,0,pujoa001,01,CX,1/G-
+play,6,0,simma001,22,BBCFC,K
+play,6,0,choij001,22,BCCBX,13/G
+play,6,1,zobrb001,01,CX,43/G
+play,6,1,russa002,02,SCS,K
+play,6,1,heywj001,21,BBFX,E1/G-
+play,6,1,contw001,10,BX,S4/G.1-2
+play,6,1,baezj001,22,BCBCS,K
+play,7,0,sotog001,12,BCCX,9/F
+play,7,0,nolar001,00,,NP
+sub,pennc001,"Cliff Pennington",0,8,11
+play,7,0,pennc001,01,.FX,31/G
+play,7,0,petig001,12,CBFFS,K23
+play,7,1,hammj002,00,,NP
+sub,pennc001,"Cliff Pennington",0,8,4
+play,7,1,hammj002,00,,NP
+sub,guerd001,"Deolis Guerra",0,9,1
+play,7,1,hammj002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,7,1,szczm001,22,...FLBFBX,9/L
+play,7,1,fowld001,21,BBCX,63/G
+play,7,1,bryak001,22,SBFBX,8/F
+play,8,0,escoy001,00,,NP
+sub,strop001,"Pedro Strop",1,9,1
+play,8,0,escoy001,20,.BBX,S1/G-
+play,8,0,calhk001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,calhk001,00,.X,D7/L.1-3
+play,8,0,troum001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,8,0,troum001,22,.FB*BSS,K
+play,8,0,pujoa001,32,FFFF*B*B*BX,43/G+.3-H;2-3
+play,8,0,simma001,00,X,63/G
+play,8,1,rizza001,00,,NP
+sub,ramij002,"J.C. Ramirez",0,9,1
+play,8,1,rizza001,00,.X,3/G-
+play,8,1,zobrb001,22,CBBCFFFFFX,8/F
+play,8,1,russa002,12,CBTX,HR/78/F
+play,8,1,heywj001,00,X,43/G-
+play,9,0,choij001,00,,NP
+sub,chapa001,"Aroldis Chapman",1,9,1
+play,9,0,choij001,00,,NP
+sub,bandj001,"Jett Bandy",0,6,11
+play,9,0,bandj001,22,..BBCFFS,K
+play,9,0,sotog001,22,BCBCS,K
+play,9,0,pennc001,22,SFBBS,K
+data,er,nolar001,2
+data,er,guerd001,0
+data,er,ramij002,1
+data,er,hammj002,0
+data,er,strop001,1
+data,er,woodt004,0
+data,er,edwac001,0
+data,er,chapa001,0
+id,CHN201608110
+version,2
+info,visteam,SLN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/11
+info,number,0
+info,starttime,7:07PM
+info,daynight,night
+info,usedh,false
+info,umphome,kulpr901
+info,ump1b,conrc901
+info,ump2b,mealj901
+info,ump3b,belld901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,87
+info,winddir,tocf
+info,windspeed,9
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,235
+info,attendance,40597
+info,wp,montm002
+info,lp,dukez001
+info,save,
+start,carpm002,"Matt Carpenter",0,1,3
+start,piscs001,"Stephen Piscotty",0,2,8
+start,hollm001,"Matt Holliday",0,3,7
+start,mossb001,"Brandon Moss",0,4,9
+start,moliy001,"Yadier Molina",0,5,2
+start,peraj001,"Jhonny Peralta",0,6,5
+start,gyorj001,"Jedd Gyorko",0,7,4
+start,garcg002,"Greg Garcia",0,8,6
+start,martc006,"Carlos Martinez",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,coghc001,"Chris Coghlan",1,7,7
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,carpm002,00,X,8/F
+play,1,0,piscs001,10,BX,9/F
+play,1,0,hollm001,22,CBSBX,S8/L
+play,1,0,mossb001,01,SX,S7/L.1-3
+play,1,0,moliy001,00,X,S39/G.3-H;1-3
+play,1,0,peraj001,00,X,5/L
+play,1,1,fowld001,32,CBBFBC,K
+play,1,1,bryak001,22,FBSBC,K
+play,1,1,rizza001,22,BFBFFFX,5/P
+play,2,0,gyorj001,22,BFFBS,K
+play,2,0,garcg002,02,CSX,6/L
+play,2,0,martc006,02,SSS,K
+play,2,1,zobrb001,30,BBBB,W
+play,2,1,russa002,32,FBFBBFFB,W.1-2
+play,2,1,heywj001,01,CX,46(1)3/GDP.2-3
+play,2,1,coghc001,02,FFX,3/G
+play,3,0,carpm002,11,CBX,9/F
+play,3,0,piscs001,22,BBCSS,K
+play,3,0,hollm001,22,BCBCX,53/G
+play,3,1,rossd001,22,BCSFFBX,63/G
+play,3,1,lestj001,10,BX,8/F
+play,3,1,fowld001,12,FBFX,7/F-
+play,4,0,mossb001,32,BBSFBFC,K
+play,4,0,moliy001,00,X,D7/G
+play,4,0,peraj001,32,CBFBBX,63/G.2-3
+play,4,0,gyorj001,31,BBBC*B,W
+play,4,0,garcg002,01,FX,43/G
+play,4,1,bryak001,22,BBCSS,K
+play,4,1,rizza001,00,X,T9/L+
+play,4,1,zobrb001,00,X,43/G
+play,4,1,russa002,12,TFBFX,53/G
+play,5,0,martc006,22,CLFBBX,53/G
+play,5,0,carpm002,12,CFBFS,K
+play,5,0,piscs001,12,BSFFFC,K
+play,5,1,heywj001,12,CFBX,43/G
+play,5,1,coghc001,30,BBBB,W
+play,5,1,rossd001,11,S*BX,D8/F.1-3
+play,5,1,lestj001,22,P+3CBSX,FC1/BG.3XH(1);2-3
+play,5,1,fowld001,32,BCBCB>F>X,3/L
+play,6,0,hollm001,00,X,53/G-
+play,6,0,mossb001,21,CBBX,HR/89/F
+play,6,0,moliy001,12,BCFFFFX,8/F-
+play,6,0,peraj001,22,BCBFX,7/L
+play,6,1,bryak001,11,BCX,S8/L
+play,6,1,rizza001,21,BBSX,S8/L.1-2
+play,6,1,zobrb001,02,FSS,K
+play,6,1,russa002,21,CBBX,3/P3F
+play,6,1,heywj001,12,BCFFX,S5/G.2-3;1-2
+play,6,1,coghc001,32,CBBBC>F>X,S9/L.3-H;2-H;1-3
+play,6,1,rossd001,01,CX,S1/BG.3-H;1-2
+play,6,1,lestj001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,6,1,szczm001,00,.X,3/P3F
+play,7,0,gyorj001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,7,0,gyorj001,10,.BX,S8/L
+play,7,0,garcg002,32,BFB1FB+1,PO1(23)
+play,7,0,garcg002,32,BFB1FB+1.FS,K
+play,7,0,martc006,00,,NP
+sub,gricr001,"Randal Grichuk",0,9,11
+play,7,0,gricr001,11,.BTX,HR/78/F
+play,7,0,carpm002,22,BCSBX,S8/L
+play,7,0,piscs001,00,,NP
+sub,smitj002,"Joe Smith",1,9,1
+play,7,0,piscs001,00,.1X,D7/L+.1XH(762)
+play,7,1,fowld001,00,,NP
+sub,siegk001,"Kevin Siegrist",0,9,1
+play,7,1,fowld001,22,.CFBBFS,K
+play,7,1,bryak001,20,BBX,8/F
+play,7,1,rizza001,20,BBX,9/L
+play,8,0,hollm001,32,BBCCFBFB,W
+play,8,0,mossb001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,8,0,mossb001,02,.TCS,K
+play,8,0,moliy001,11,BFX,8/F
+play,8,0,peraj001,21,BBCX,64(1)/FO/G
+play,8,1,zobrb001,00,,NP
+sub,bowmm001,"Matt Bowman",0,9,1
+play,8,1,zobrb001,11,.BCX,13/G
+play,8,1,russa002,11,BFX,D8/L+
+play,8,1,heywj001,02,CSX,13/G-.2-3
+play,8,1,coghc001,32,CBBFBX,13/G
+play,9,0,gyorj001,00,,NP
+sub,bryak001,"Kris Bryant",1,2,7
+play,9,0,gyorj001,00,,NP
+sub,chapa001,"Aroldis Chapman",1,7,1
+play,9,0,gyorj001,00,,NP
+sub,baezj001,"Javier Baez",1,9,5
+play,9,0,gyorj001,00,...X,5/L
+play,9,0,garcg002,00,X,5/L+
+play,9,0,bowmm001,00,,NP
+sub,phamt001,"Tommy Pham",0,9,11
+play,9,0,phamt001,00,.X,43/G
+play,9,1,rossd001,00,,NP
+sub,oh--s001,"Seung Hwan Oh",0,9,1
+play,9,1,rossd001,12,.BSCS,K
+play,9,1,baezj001,22,FBBSS,K
+play,9,1,fowld001,22,BSBFS,K
+play,10,0,carpm002,00,,NP
+sub,contw001,"Willson Contreras",1,7,2
+play,10,0,carpm002,00,,NP
+sub,montm002,"Mike Montgomery",1,8,1
+play,10,0,carpm002,10,..BX,43/G
+play,10,0,piscs001,10,BX,63/G+
+play,10,0,hollm001,11,CBH,HP
+play,10,0,mossb001,00,,NP
+sub,hazej001,"Jeremy Hazelbaker",0,3,12
+play,10,0,mossb001,32,.*BC1CB+111B>S,K
+play,10,1,bryak001,00,,NP
+sub,piscs001,"Stephen Piscotty",0,2,9
+play,10,1,bryak001,00,,NP
+sub,hazej001,"Jeremy Hazelbaker",0,3,8
+play,10,1,bryak001,00,,NP
+sub,mossb001,"Brandon Moss",0,4,7
+play,10,1,bryak001,12,...SFFBFFX,S3/G/MREV
+com,"replay,10,bryak001,CHN,mealj901,CHI11,,N,M,SLN,C"
+com,"$when Kris Bryant was called safe at 1B, Cardinals"
+com,"manager Mike Matheny challenged the ruling; the"
+com,"call was upheld by replay"
+play,10,1,rizza001,31,1BBBFX,5/P
+play,10,1,zobrb001,10,BB,WP.1-2
+play,10,1,zobrb001,30,BB.BB,W
+play,10,1,russa002,02,CSS,K
+play,10,1,heywj001,00,X,4/P
+play,11,0,moliy001,01,CX,S8/G
+play,11,0,peraj001,02,CSFFFC,K
+play,11,0,gyorj001,32,C*BFB*BFB,W.1-2
+play,11,0,garcg002,00,,NP
+sub,leakm001,"Mike Leake",0,5,12
+play,11,0,garcg002,32,.B*BB+2CSC,K
+play,11,0,oh--s001,00,,NP
+sub,wongk001,"Kolten Wong",0,9,11
+play,11,0,wongk001,00,.B,WP.2-3;1-2
+play,11,0,wongk001,30,.B.*BBB,W
+play,11,0,carpm002,12,CS*BS,K
+play,11,1,contw001,00,,NP
+sub,rosaa002,"Alberto Rosario",0,5,2
+play,11,1,contw001,00,,NP
+sub,dukez001,"Zach Duke",0,9,1
+play,11,1,contw001,11,..CBX,S8/L
+play,11,1,montm002,00,,NP
+sub,solej001,"Jorge Soler",1,8,11
+play,11,1,solej001,32,.F1BF*BFBFFX,S5/G-.1-2
+play,11,1,baezj001,22,C*BC*BX,7/F-
+play,11,1,fowld001,31,BFBBB,W.2-3;1-2
+play,11,1,bryak001,02,CFS,K
+play,11,1,rizza001,31,B*BCBB,W.3-H;2-3;1-2
+data,er,martc006,3
+data,er,siegk001,0
+data,er,bowmm001,0
+data,er,oh--s001,0
+data,er,dukez001,1
+data,er,lestj001,2
+data,er,woodt004,1
+data,er,smitj002,0
+data,er,grimj002,0
+data,er,chapa001,0
+data,er,montm002,0
+id,CHN201608120
+version,2
+info,visteam,SLN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/12
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,conrc901
+info,ump1b,mealj901
+info,ump2b,belld901
+info,ump3b,kulpr901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,76
+info,winddir,tocf
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,179
+info,attendance,40848
+info,wp,arrij001
+info,lp,waina001
+info,save,
+start,carpm002,"Matt Carpenter",0,1,3
+start,piscs001,"Stephen Piscotty",0,2,9
+start,mossb001,"Brandon Moss",0,3,7
+start,moliy001,"Yadier Molina",0,4,2
+start,gyorj001,"Jedd Gyorko",0,5,5
+start,garcg002,"Greg Garcia",0,6,6
+start,gricr001,"Randal Grichuk",0,7,8
+start,wongk001,"Kolten Wong",0,8,4
+start,waina001,"Adam Wainwright",0,9,1
+start,szczm001,"Matt Szczur",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,solej001,"Jorge Soler",1,4,9
+start,russa002,"Addison Russell",1,5,6
+start,contw001,"Willson Contreras",1,6,7
+start,montm001,"Miguel Montero",1,7,2
+start,baezj001,"Javier Baez",1,8,4
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,carpm002,02,FCS,K
+play,1,0,piscs001,02,CCFX,43/G
+play,1,0,mossb001,22,BFSBC,K
+play,1,1,szczm001,21,CBBX,D9/G
+play,1,1,bryak001,11,BFX,D7/L.2-H
+play,1,1,rizza001,31,CBB*BB,W
+play,1,1,solej001,00,X,54(1)/FO/G.2-3
+play,1,1,russa002,10,BX,D8/L+.3-H;1-3
+play,1,1,contw001,12,CBSS,K
+play,1,1,montm001,32,BBFBCFFB,W
+play,1,1,baezj001,12,CFBX,5(2)/FO/G.1-2
+play,2,0,moliy001,02,CFX,9/F-
+play,2,0,gyorj001,22,BFCBX,E5/TH/G.B-2
+play,2,0,garcg002,32,CBCBBB,W
+play,2,0,gricr001,02,CFS,K
+play,2,0,wongk001,22,FBCBFX,43/G
+play,2,1,arrij001,22,FBFBFFC,K
+play,2,1,szczm001,00,H,HP
+play,2,1,bryak001,00,X,D8/L+.1-H
+play,2,1,rizza001,10,BX,5/P-
+play,2,1,solej001,01,CX,S8/L-.2-H
+play,2,1,russa002,32,FBSB*B>B,W.1-2
+play,2,1,contw001,00,X,HR/78/L.2-H;1-H
+play,2,1,montm001,22,BSSBX,43/G
+play,3,0,waina001,32,BBBCCX,D7/L-
+play,3,0,carpm002,21,BFBX,7/F
+play,3,0,piscs001,12,SFBX,3/P3F
+play,3,0,mossb001,11,SBX,8/L
+play,3,1,baezj001,00,,NP
+sub,manes001,"Seth Maness",0,9,1
+play,3,1,baezj001,10,.BX,63/G
+play,3,1,arrij001,01,CX,S7/L
+play,3,1,szczm001,12,SBFC,K
+play,3,1,bryak001,12,S*BSFFX,64(1)/FO/G
+play,4,0,moliy001,12,FFBFFFS,K
+play,4,0,gyorj001,10,BX,S7/G
+play,4,0,garcg002,31,BBBCX,E4/FO/G.1-2
+play,4,0,gricr001,12,CFFFBC,K
+play,4,0,wongk001,32,BCBS*B>B,W.2-3;1-2
+play,4,0,manes001,00,,NP
+sub,hazej001,"Jeremy Hazelbaker",0,9,11
+play,4,0,hazej001,01,.CX,7/L
+play,4,1,rizza001,00,,NP
+sub,rosaa002,"Alberto Rosario",0,4,2
+play,4,1,rizza001,00,,NP
+sub,broxj001,"Jonathan Broxton",0,9,1
+play,4,1,rizza001,12,..CBSX,43/G
+play,4,1,solej001,12,FSBX,13/G
+play,4,1,russa002,00,X,53/G
+play,5,0,carpm002,22,BBCFFX,31/G
+play,5,0,piscs001,11,SBX,HR/8/F
+play,5,0,mossb001,12,CCFFBS,K
+play,5,0,rosaa002,10,BX,63/G
+play,5,1,contw001,32,CFFBFBFBT,K
+play,5,1,montm001,22,BFSFBFX,8/F
+play,5,1,baezj001,10,BX,S5/G+
+play,5,1,arrij001,22,BBCFFS,K
+play,6,0,gyorj001,11,BCX,13/G-
+play,6,0,garcg002,10,BX,13/G
+play,6,0,gricr001,11,BFX,D8/L
+play,6,0,wongk001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,6,0,wongk001,11,.*BSB,WP.2-3
+play,6,0,wongk001,32,.*BSB.BFS,K
+play,6,1,szczm001,00,,NP
+sub,willj003,"Jerome Williams",0,1,1
+play,6,1,szczm001,00,,NP
+sub,mossb001,"Brandon Moss",0,3,3
+play,6,1,szczm001,00,,NP
+sub,phamt001,"Tommy Pham",0,9,7
+play,6,1,szczm001,11,...FBX,HR/78/F
+play,6,1,bryak001,22,CSBBS,K
+play,6,1,rizza001,11,BFX,5/P5F
+play,6,1,solej001,11,FBX,HR/78/F
+play,6,1,russa002,32,BSBFBFS,K
+play,7,0,phamt001,11,BCX,8/L
+play,7,0,willj003,00,X,2/P2F
+play,7,0,piscs001,11,BFX,8/L
+play,7,1,contw001,12,SBFX,S7/L
+play,7,1,montm001,10,BX,8/F
+play,7,1,baezj001,22,CBSBX,HR/7/L.1-H
+play,7,1,grimj002,00,,NP
+sub,coghc001,"Chris Coghlan",1,9,11
+play,7,1,coghc001,32,.FBBBFH,HP
+play,7,1,szczm001,01,CX,HR/7/F.1-H
+play,7,1,bryak001,00,X,S7/L
+play,7,1,rizza001,02,CFX,7/F
+play,7,1,solej001,32,FBSBB>B,W.1-2
+play,7,1,russa002,00,X,31/G-
+play,8,0,mossb001,00,,NP
+sub,smitj002,"Joe Smith",1,3,1
+play,8,0,mossb001,00,,NP
+sub,coghc001,"Chris Coghlan",1,9,3
+play,8,0,mossb001,12,..FBFFS,K
+play,8,0,rosaa002,22,CBBFX,8/L
+play,8,0,gyorj001,31,CBBBX,HR/78/F
+play,8,0,garcg002,01,FX,6/P
+play,8,1,contw001,02,CSX,43/G
+play,8,1,montm001,00,X,43/G
+play,8,1,baezj001,11,CBX,4/P
+play,9,0,gricr001,00,,NP
+sub,woodt004,"Travis Wood",1,3,1
+play,9,0,gricr001,00,.X,7/F
+play,9,0,wongk001,22,CFBBFX,63/G
+play,9,0,phamt001,32,BFSBBB,W
+play,9,0,willj003,00,,NP
+sub,peraj001,"Jhonny Peralta",0,1,11
+play,9,0,peraj001,10,.BX,S8/L-.1-2
+play,9,0,piscs001,00,X,54(1)/FO/G
+data,er,waina001,7
+data,er,manes001,0
+data,er,broxj001,0
+data,er,willj003,6
+data,er,arrij001,1
+data,er,grimj002,0
+data,er,smitj002,1
+data,er,woodt004,0
+id,CHN201608130
+version,2
+info,visteam,SLN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/13
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,mealj901
+info,ump1b,belld901
+info,ump2b,kulpr901
+info,ump3b,conrc901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,83
+info,winddir,ltor
+info,windspeed,11
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,170
+info,attendance,41278
+info,wp,reyea004
+info,lp,edwac001
+info,save,
+start,garcg002,"Greg Garcia",0,1,6
+start,piscs001,"Stephen Piscotty",0,2,9
+start,carpm002,"Matt Carpenter",0,3,3
+start,mossb001,"Brandon Moss",0,4,7
+start,moliy001,"Yadier Molina",0,5,2
+start,peraj001,"Jhonny Peralta",0,6,5
+start,gyorj001,"Jedd Gyorko",0,7,4
+start,gricr001,"Randal Grichuk",0,8,8
+start,weavl001,"Luke Weaver",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,7
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,contw001,"Willson Contreras",1,7,2
+start,baezj001,"Javier Baez",1,8,4
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,garcg002,12,CFBC,K
+play,1,0,piscs001,32,FBBSBFH,HP
+play,1,0,carpm002,22,BBFFS,K
+play,1,0,mossb001,12,F1BSFS,K
+play,1,1,fowld001,12,CBSFC,K
+play,1,1,bryak001,22,BBFSFS,K
+play,1,1,rizza001,32,BBFBFX,3/G
+play,2,0,moliy001,00,X,S8/L
+play,2,0,peraj001,02,FFS,K
+play,2,0,gyorj001,22,FB*BS1FS,K
+play,2,0,gricr001,22,FBBSS,K
+play,2,1,zobrb001,21,BBCX,D9/L+
+play,2,1,russa002,32,CBBFBFFFX,HR/7/F.2-H
+play,2,1,heywj001,01,CX,9/F
+play,2,1,contw001,30,BBBB,W
+play,2,1,baezj001,12,CCFF1BX,S8/L-.1-3
+play,2,1,hendk001,10,BX,FC1/BG.3XH(12);1-2
+play,2,1,fowld001,31,BBCBB,W.2-3;1-2
+play,2,1,bryak001,22,FC*B*BFX,63/G
+play,3,0,weavl001,11,CBX,43/G
+play,3,0,garcg002,12,SBFX,6/L
+play,3,0,piscs001,11,BSX,S9/L
+play,3,0,carpm002,22,BCC*B1S,K
+play,3,1,rizza001,02,CFFX,S8/F-
+play,3,1,zobrb001,20,BBX,3(B)63(1)/GDP
+play,3,1,russa002,32,BBCCFBB,W
+play,3,1,heywj001,21,B+1SBX,41/G
+play,4,0,mossb001,02,CSS,K
+play,4,0,moliy001,01,SX,S7/L
+play,4,0,peraj001,12,BCSC,K
+play,4,0,gyorj001,12,CSB>X,53/G
+play,4,1,contw001,00,X,3/G-
+play,4,1,baezj001,20,BBX,43/G
+play,4,1,hendk001,22,SSBFBFFS,K
+play,5,0,gricr001,10,BX,5/L
+play,5,0,weavl001,00,,NP
+sub,wongk001,"Kolten Wong",0,9,11
+play,5,0,wongk001,00,.X,43/G
+play,5,0,garcg002,21,CBBX,63/G
+play,5,1,fowld001,00,,NP
+sub,reyea004,"Alex Reyes",0,9,1
+play,5,1,fowld001,12,.BFCX,S9/G
+play,5,1,bryak001,02,FCS,K
+play,5,1,rizza001,12,BF1FX,4/L
+play,5,1,zobrb001,22,B1BFF>B,CS2(26)
+play,6,0,piscs001,12,FFBFX,7/F
+play,6,0,carpm002,22,BCBFS,K
+play,6,0,mossb001,00,X,HR/89/F
+play,6,0,moliy001,10,BX,13/G-
+play,6,1,zobrb001,32,BCBCBX,8/L+
+play,6,1,russa002,31,BBFBB,W
+play,6,1,heywj001,22,BCFBX,5/L/DP.1X1(53)
+play,7,0,peraj001,00,X,4/L
+play,7,0,gyorj001,21,BCBX,HR/7/F
+play,7,0,gricr001,22,CBSBS,K
+play,7,0,reyea004,32,CBSBBS,K
+play,7,1,contw001,32,CBBBSFFFS,K
+play,7,1,baezj001,22,CBBFC,K
+play,7,1,hendk001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,7,1,szczm001,22,.FCBBX,63/G
+play,8,0,garcg002,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,8,0,garcg002,12,.BSFX,8/L
+play,8,0,piscs001,32,BBCFBFFFB,W
+play,8,0,carpm002,20,B11BX,S9/G.1-2
+play,8,0,mossb001,31,BFBBB,W.2-3;1-2
+play,8,0,moliy001,12,FBTS,K+WP.3-H;2-3;1-2
+play,8,0,peraj001,30,BBBB,W
+play,8,0,gyorj001,30,BBBB,W.3-H;2-3;1-2
+play,8,0,gricr001,00,,NP
+sub,smitj002,"Joe Smith",1,9,1
+play,8,0,gricr001,01,.SX,HR/8/L.3-H;2-H;1-H
+play,8,0,reyea004,00,,NP
+sub,hazej001,"Jeremy Hazelbaker",0,9,11
+play,8,0,hazej001,10,.BX,5/P
+play,8,1,fowld001,00,,NP
+sub,siegk001,"Kevin Siegrist",0,9,1
+play,8,1,fowld001,32,.BCBFFBX,63/G
+play,8,1,bryak001,31,BBCBX,63/G
+play,8,1,rizza001,12,CBSX,43/G
+play,9,0,garcg002,00,,NP
+sub,montm002,"Mike Montgomery",1,9,1
+play,9,0,garcg002,00,.X,63/G
+play,9,0,piscs001,22,BBSFS,K
+play,9,0,carpm002,21,BBCX,S9/L
+play,9,0,mossb001,00,X,5/L+
+play,9,1,zobrb001,00,,NP
+sub,manes001,"Seth Maness",0,9,1
+play,9,1,zobrb001,32,.BCFBBX,S8/G+
+play,9,1,russa002,00,X,S8/G+.1-2
+play,9,1,heywj001,02,CFX,S1/G.2-H(E1/TH)(NR);1-3;B-2
+play,9,1,contw001,00,,NP
+sub,dukez001,"Zach Duke",0,9,1
+play,9,1,contw001,00,.X,9/F
+play,9,1,baezj001,11,BCX,53/G.3-H(UR)
+play,9,1,montm002,00,,NP
+sub,solej001,"Jorge Soler",1,9,11
+play,9,1,solej001,00,.X,63/G
+data,er,weavl001,2
+data,er,reyea004,0
+data,er,siegk001,0
+data,er,manes001,1
+data,er,dukez001,0
+data,er,hendk001,2
+data,er,edwac001,5
+data,er,smitj002,1
+data,er,montm002,0
+id,CHN201608140
+version,2
+info,visteam,SLN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/14
+info,number,0
+info,starttime,7:09PM
+info,daynight,night
+info,usedh,false
+info,umphome,belld901
+info,ump1b,kulpr901
+info,ump2b,conrc901
+info,ump3b,mealj901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,speaa701
+info,temp,78
+info,winddir,fromrf
+info,windspeed,6
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,182
+info,attendance,41019
+info,wp,bowmm001
+info,lp,rondh001
+info,save,oh--s001
+start,garcg002,"Greg Garcia",0,1,6
+start,piscs001,"Stephen Piscotty",0,2,9
+start,carpm002,"Matt Carpenter",0,3,3
+start,mossb001,"Brandon Moss",0,4,7
+start,moliy001,"Yadier Molina",0,5,2
+start,peraj001,"Jhonny Peralta",0,6,5
+start,gyorj001,"Jedd Gyorko",0,7,4
+start,gricr001,"Randal Grichuk",0,8,8
+start,leakm001,"Mike Leake",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,coghc001,"Chris Coghlan",1,6,7
+start,heywj001,"Jason Heyward",1,7,9
+start,contw001,"Willson Contreras",1,8,2
+start,lackj001,"John Lackey",1,9,1
+play,1,0,garcg002,22,CFFFBBFX,3/L
+play,1,0,piscs001,00,X,8/F
+play,1,0,carpm002,11,CBX,7/F
+play,1,1,fowld001,32,CCBBBFB,W
+play,1,1,bryak001,00,X,S9/L.1-2
+play,1,1,rizza001,00,X,S9/G.2-H;1-3
+play,1,1,zobrb001,01,CX,7/F/SF.3-H
+play,1,1,russa002,10,BX,54(1)/FO/G
+play,1,1,coghc001,00,X,3/G
+play,2,0,mossb001,00,X,S9/L
+play,2,0,moliy001,32,F1C*BBB>S,K+SB2
+play,2,0,peraj001,10,BX,63/G.2-3
+play,2,0,gyorj001,32,FBBBCFB,W
+play,2,0,gricr001,22,SBFBFS,K
+play,2,1,heywj001,02,CFC,K
+play,2,1,contw001,21,BBFX,13/G-
+play,2,1,lackj001,12,CSBS,K
+play,3,0,leakm001,32,BBFFFFBX,8/F
+play,3,0,garcg002,21,BBSX,S4/L
+play,3,0,piscs001,00,H,HP.1-2
+play,3,0,carpm002,12,CC*BFX,64(1)/FO/G.2-H(E4/TH)(UR)(NR)
+play,3,0,mossb001,00,X,7/F
+play,3,1,fowld001,10,BX,5/L
+play,3,1,bryak001,32,CBCFBBX,43/G
+play,3,1,rizza001,21,FBBX,53/G
+play,4,0,moliy001,00,X,S67/G
+play,4,0,peraj001,22,C*BSBX,54(1)3/GDP
+play,4,0,gyorj001,22,BSSBS,K
+play,4,1,zobrb001,00,X,1/G-
+play,4,1,russa002,12,CFFBFX,53/G
+play,4,1,coghc001,20,BBX,43/G
+play,5,0,gricr001,22,CCBBX,7/F
+play,5,0,leakm001,22,BBSTS,K
+play,5,0,garcg002,32,BBCBCS,K
+play,5,1,heywj001,20,BBX,53/G
+play,5,1,contw001,22,CBCBS,K
+play,5,1,lackj001,12,BSSS,K
+play,6,0,piscs001,01,CX,9/F
+play,6,0,carpm002,11,BSX,3/G
+play,6,0,mossb001,00,X,31/G
+play,6,1,fowld001,00,X,3/G
+play,6,1,bryak001,10,BX,T8/F
+play,6,1,rizza001,21,BBCX,S7/L.3-H
+play,6,1,zobrb001,21,CBB1>X,3/G.1-2
+play,6,1,russa002,10,*BX,8/F
+play,7,0,moliy001,12,CBFX,S8/G
+play,7,0,peraj001,12,BCFX,64(1)/FO/G
+play,7,0,gyorj001,32,CBFBBFX,5/L
+play,7,0,gricr001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,7,0,gricr001,22,SSBF*B.S,K23
+play,7,1,coghc001,20,BBX,D7/L
+play,7,1,heywj001,00,X,S5/G-/MREV.2-3
+com,"replay,7,heywj001,CHN,mealj901,CHI11,,N,M,SLN,C"
+com,"$when Jason Heyward was called safe at 1B, Cardinals"
+com,"manager Mike Matheny challenged the ruling; the"
+com,"call was upheld by replay"
+play,7,1,contw001,00,,NP
+sub,bowmm001,"Matt Bowman",0,9,1
+play,7,1,contw001,32,.CBB+3>FBF*B,W.1-2
+play,7,1,grimj002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,7,1,szczm001,00,.X,8/F
+play,7,1,fowld001,22,BFBFC,K
+play,7,1,bryak001,21,BCBX,9/F
+play,8,0,bowmm001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,8,0,bowmm001,00,,NP
+sub,baezj001,"Javier Baez",1,6,4
+play,8,0,bowmm001,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,8,0,bowmm001,00,,NP
+sub,wongk001,"Kolten Wong",0,9,11
+play,8,0,wongk001,22,....BCSBX,S7/L
+play,8,0,garcg002,21,B*BF1X,S1/BG.1-2
+play,8,0,piscs001,11,BFX,HR/8/F.2-H;1-H
+play,8,0,carpm002,22,CBTFBX,3/G
+play,8,0,mossb001,21,LBBX,HR/78/F
+play,8,0,moliy001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,moliy001,00,.X,9/F
+play,8,0,peraj001,32,BCBFBB,W
+play,8,0,gyorj001,21,BBFX,S9/L.1-2
+play,8,0,gricr001,00,X,D9/L.2-H;1-3
+play,8,0,wongk001,22,FBCBFX,8/F
+play,8,1,rizza001,00,,NP
+sub,siegk001,"Kevin Siegrist",0,9,1
+play,8,1,rizza001,10,.BX,HR/9/F
+play,8,1,zobrb001,32,LBFBBC,K
+play,8,1,russa002,00,,NP
+sub,oh--s001,"Seung Hwan Oh",0,9,1
+play,8,1,russa002,02,.CSS,K
+play,8,1,baezj001,21,BBSX,S7/L
+play,8,1,heywj001,22,CBFBFF1X,7/F
+play,9,0,garcg002,00,,NP
+sub,chapa001,"Aroldis Chapman",1,7,1
+play,9,0,garcg002,00,,NP
+sub,solej001,"Jorge Soler",1,9,9
+play,9,0,garcg002,32,..BBBCCS,K
+play,9,0,piscs001,32,SBSBBFS,K
+play,9,0,carpm002,02,SSX,31/G
+play,9,1,contw001,22,FSBBFFS,K
+play,9,1,solej001,22,SBBFC,K
+play,9,1,fowld001,12,FBFS,K
+data,er,leakm001,3
+data,er,bowmm001,0
+data,er,siegk001,1
+data,er,oh--s001,0
+data,er,lackj001,0
+data,er,grimj002,0
+data,er,rondh001,4
+data,er,woodt004,1
+data,er,chapa001,0
+id,CHN201608161
+version,2
+info,visteam,MIL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/16
+info,number,1
+info,starttime,12:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,torrc901
+info,ump1b,woodt901
+info,ump2b,davig901
+info,ump3b,drakr901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,80
+info,winddir,fromlf
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,192
+info,attendance,41148
+info,wp,cahit001
+info,lp,garzm001
+info,save,chapa001
+start,villj001,"Jonathan Villar",0,1,5
+start,arcio002,"Orlando Arcia",0,2,6
+start,genns001,"Scooter Gennett",0,3,4
+start,cartc002,"Chris Carter",0,4,3
+start,pereh001,"Hernan Perez",0,5,9
+start,nieuk001,"Kirk Nieuwenhuis",0,6,7
+start,broxk001,"Keon Broxton",0,7,8
+start,pinam001,"Manny Pina",0,8,2
+start,garzm001,"Matt Garza",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,coghc001,"Chris Coghlan",1,6,7
+start,heywj001,"Jason Heyward",1,7,9
+start,montm001,"Miguel Montero",1,8,2
+start,cahit001,"Trevor Cahill",1,9,1
+play,1,0,villj001,11,CBX,S8/G
+play,1,0,arcio002,10,B1,PO1(13)
+play,1,0,arcio002,20,B1.BX,4/P3F
+play,1,0,genns001,22,CCFBBT,K
+play,1,1,fowld001,32,CBCBFBX,S9/G
+play,1,1,bryak001,00,X,54(1)/FO/L
+play,1,1,rizza001,22,BS*BSX,S8/L.1-3
+play,1,1,zobrb001,32,BBCBF>B,W.1-2
+play,1,1,russa002,02,SFX,7/F/SF.3-H
+play,1,1,coghc001,12,LFBFFX,63/G
+play,2,0,cartc002,32,CBFBBX,43/G
+play,2,0,pereh001,11,SBX,63/G
+play,2,0,nieuk001,10,BX,S9/L
+play,2,0,broxk001,02,CC>B,CS2(26)
+play,2,1,heywj001,22,BBCCX,53/G
+play,2,1,montm001,22,SSBFFFBS,K
+play,2,1,cahit001,02,FSFC,K
+play,3,0,broxk001,01,SX,13/G
+play,3,0,pinam001,22,CBFBX,7/F
+play,3,0,garzm001,31,BBCBB,W
+play,3,0,villj001,22,CBCBFS,K
+play,3,1,fowld001,32,CBFBBFB,W
+play,3,1,bryak001,10,BX,3/P3F
+play,3,1,rizza001,12,FBFFX,S7/G.1-2
+play,3,1,zobrb001,32,CBCB*BX,46(1)/FO/G.2-3
+play,3,1,russa002,00,B,WP.3-H(NR);1-2
+play,3,1,russa002,11,B.FX,5/P5F
+play,4,0,arcio002,32,CBFBFBFX,63/G
+play,4,0,genns001,01,FX,7/F
+play,4,0,cartc002,22,BSFFBFX,63/G
+play,4,1,coghc001,12,BCSX,D7/L-
+play,4,1,heywj001,00,X,9/F
+play,4,1,montm001,00,X,S6/G-.2-3
+play,4,1,cahit001,32,BBBCLX,FC3/BG-/SH.3-H;1-2
+play,4,1,fowld001,32,BCS*BBB,W.2-3;1-2
+play,4,1,bryak001,20,B*BX,2/P/IF
+play,4,1,rizza001,00,X,3/G+
+play,5,0,pereh001,31,BBCBX,63/G
+play,5,0,nieuk001,22,CBBSFX,31/G
+play,5,0,broxk001,32,CBBSB*B,W
+play,5,0,pinam001,00,1>B,SB2.1-3(E2/TH)
+play,5,0,pinam001,12,1>B.CFFS,K
+play,5,1,zobrb001,22,BCCBX,43/G
+play,5,1,russa002,11,BCX,23/G-
+play,5,1,coghc001,22,FBCBX,43/G-
+play,6,0,garzm001,00,,NP
+sub,montm002,"Mike Montgomery",1,9,1
+play,6,0,garzm001,00,,NP
+sub,elmoj001,"Jake Elmore",0,9,11
+play,6,0,elmoj001,10,..BX,43/G
+play,6,0,villj001,02,SCFS,K
+play,6,0,arcio002,32,BBFBSB,W
+play,6,0,genns001,12,BFFX,43/G
+play,6,1,heywj001,00,,NP
+sub,cravt001,"Tyler Cravy",0,9,1
+play,6,1,heywj001,01,.CX,9/F
+play,6,1,montm001,12,BSSFS,K
+play,6,1,montm002,12,BSSX,1/G-
+play,7,0,cartc002,01,CH,HP
+play,7,0,pereh001,02,CSX,7/F
+play,7,0,nieuk001,02,CSS,K
+play,7,0,broxk001,11,B1C>S,SB2
+play,7,0,broxk001,12,B1C>S.S,K
+play,7,1,fowld001,11,BFX,8/L
+play,7,1,bryak001,12,CCBFX,S7/L
+play,7,1,rizza001,02,CSF1S,K
+play,7,1,zobrb001,20,BB>B,CS2(26)
+play,8,0,pinam001,21,BCBX,S9/L
+play,8,0,cravt001,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,8,0,cravt001,00,,NP
+sub,braur002,"Ryan Braun",0,9,11
+play,8,0,braur002,00,..X,8/F
+play,8,0,villj001,22,CSBBB,WP.1-2
+play,8,0,villj001,32,CSBBB.FB,W
+play,8,0,arcio002,10,BX,3/P/IF
+play,8,0,genns001,22,BCFFBX,5/P5F
+play,8,1,zobrb001,00,,NP
+sub,magnd001,"Damien Magnifico",0,9,1
+play,8,1,zobrb001,30,.BBBB,W
+play,8,1,russa002,11,CB1H,HP.1-2
+play,8,1,coghc001,00,B,WP.2-3;1-2
+play,8,1,coghc001,31,B.BCBX,9/L/SF/MREV.3-H
+com,"replay,8,coghc001,CHN,davig901,CHI11,,N,M,MIL,A"
+com,"$when Ben Zobrist was called safe at HP, Brewers"
+com,"manager Craig Counsell challenged the ruling; the"
+com,"call was upheld by replay"
+play,8,1,heywj001,31,BCB*BX,8/F
+play,8,1,montm001,21,CBBX,9/F
+play,9,0,cartc002,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,9,0,cartc002,00,,NP
+sub,contw001,"Willson Contreras",1,6,2
+play,9,0,cartc002,00,,NP
+sub,smitj002,"Joe Smith",1,8,1
+play,9,0,cartc002,00,,NP
+sub,baezj001,"Javier Baez",1,9,4
+play,9,0,cartc002,32,....CBBBCB,W
+play,9,0,pereh001,00,X,54(1)/FO/G+
+play,9,0,nieuk001,32,BCCFFBBFB,W.1-2
+play,9,0,broxk001,00,,NP
+sub,chapa001,"Aroldis Chapman",1,8,1
+play,9,0,broxk001,11,.BF>B,DI.2-3;1-2
+play,9,0,broxk001,22,.BF>B.SS,K
+play,9,0,pinam001,32,CBBFBFX,2/P2F-
+data,er,garzm001,3
+data,er,cravt001,0
+data,er,magnd001,1
+data,er,cahit001,0
+data,er,montm002,0
+data,er,rondh001,0
+data,er,smitj002,0
+data,er,chapa001,0
+id,CHN201608162
+version,2
+info,visteam,MIL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/16
+info,number,2
+info,starttime,7:05PM
+info,daynight,night
+info,usedh,false
+info,umphome,holbs901
+info,ump1b,davig901
+info,ump2b,drakr901
+info,ump3b,woodt901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,76
+info,winddir,rtol
+info,windspeed,3
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,201
+info,attendance,39420
+info,wp,hammj002
+info,lp,marij001
+info,save,chapa001
+start,villj001,"Jonathan Villar",0,1,6
+start,genns001,"Scooter Gennett",0,2,4
+start,braur002,"Ryan Braun",0,3,7
+start,pereh001,"Hernan Perez",0,4,5
+start,cartc002,"Chris Carter",0,5,3
+start,nieuk001,"Kirk Nieuwenhuis",0,6,9
+start,broxk001,"Keon Broxton",0,7,8
+start,maldm001,"Martin Maldonado",0,8,2
+start,andec001,"Chase Anderson",0,9,1
+start,szczm001,"Matt Szczur",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,solej001,"Jorge Soler",1,4,9
+start,zobrb001,"Ben Zobrist",1,5,4
+start,contw001,"Willson Contreras",1,6,7
+start,baezj001,"Javier Baez",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,villj001,32,FBCBBX,63/G
+play,1,0,genns001,32,BSBFFBS,K
+play,1,0,braur002,02,CCX,7/F
+play,1,1,szczm001,22,CBLBFX,6/P
+play,1,1,bryak001,22,BBFCX,13/L
+play,1,1,rizza001,00,,NP
+sub,marij001,"Jhan Marinez",0,9,1
+com,"Brewers pitcher Chase Anderson left the game due to an injured leg"
+play,1,1,rizza001,00,.X,43/G
+play,2,0,pereh001,02,CCX,8/L
+play,2,0,cartc002,22,BFCBS,K
+play,2,0,nieuk001,32,BBTSBB,W
+play,2,0,broxk001,02,1CSC,K
+play,2,1,solej001,32,FBFFFFBBB,W
+play,2,1,zobrb001,32,CBBBC>FX,4/L/DP.1X1(43)
+play,2,1,contw001,01,CX,63/G
+play,3,0,maldm001,00,X,8/F
+play,3,0,marij001,01,CX,3/P
+play,3,0,villj001,12,LBFT,K
+play,3,1,baezj001,11,BTX,8/F
+play,3,1,rossd001,32,BCBBCB,W
+play,3,1,hammj002,01,FX,S7/G.1-2
+play,3,1,szczm001,10,*BX,3/P3F
+play,3,1,bryak001,20,*BBX,S7/L.2-H;1-2
+play,3,1,rizza001,11,FBX,6/P
+play,4,0,genns001,22,.FBCBS,K
+play,4,0,braur002,12,SCBS,K
+play,4,0,pereh001,22,CBFBX,S8/L-
+play,4,0,cartc002,20,BB>B,SB2
+play,4,0,cartc002,30,BB>B.*B,W
+play,4,0,nieuk001,31,BFB*B+2,OA.2-3(E2/TH);1X2(46)
+play,4,1,solej001,32,FBBBFB,W
+play,4,1,zobrb001,22,1BCBF,NP
+sub,florr003,"Ramon Flores",0,3,7
+com,"Brewers left fielder Ryan Braun left the game due to an injured knee"
+play,4,1,zobrb001,32,1BCBF.*BX,S7/L.1-2
+play,4,1,contw001,31,BB*BCX,7/F
+play,4,1,baezj001,21,BB+2FX,S9/F-.2-3;1-2
+play,4,1,rossd001,00,,NP
+sub,boyeb001,"Blaine Boyer",0,9,1
+play,4,1,rossd001,02,.FFFX,5(2)3/GDP
+play,5,0,nieuk001,32,CBBFBS,K
+play,5,0,broxk001,31,.BBBCX,3/P3F
+play,5,0,maldm001,22,CCBBFX,S8/G
+play,5,0,boyeb001,11,SBX,46(1)/FO/G
+play,5,1,hammj002,32,CBBSBX,DGR/8/L
+play,5,1,szczm001,02,CFX,FC6/G.2X3(65)
+play,5,1,bryak001,11,1BFX,S5/G+.1-2
+play,5,1,rizza001,01,FX,S7/L/MREV.2XH(72);1-2
+com,"replay,5,rizza001,CHN,davig901,CHI11,,N,M,CHN,A"
+com,"$when Matt Szczur was called out at HP, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was upheld by replay"
+play,5,1,solej001,01,SX,13/G-
+play,6,0,villj001,21,BCBX,63/G
+play,6,0,genns001,31,BBCBB,W
+play,6,0,florr003,01,11CX,16(1)3/GDP
+play,6,1,zobrb001,00,,NP
+sub,scahr001,"Rob Scahill",0,9,1
+play,6,1,zobrb001,22,.BCFBX,D7/F
+play,6,1,contw001,11,BFX,S9/L.2-H
+play,6,1,baezj001,01,1C1X,HR/78/F.1-H
+play,6,1,rossd001,32,CFFBBBT,K
+play,6,1,hammj002,02,FFFFX,63/G
+play,6,1,szczm001,12,BSFX,63/G
+play,7,0,pereh001,32,BFSBBX,2/P2F
+play,7,0,cartc002,32,SCBFBBX,8/F
+play,7,0,nieuk001,21,BBFX,31/G-
+play,7,1,bryak001,00,,NP
+sub,knebc001,"Corey Knebel",0,9,1
+play,7,1,bryak001,31,.BBBCB,W
+play,7,1,rizza001,31,*BBBS>C,SB2
+play,7,1,rizza001,32,*BBBS>C.X,9/F
+play,7,1,solej001,32,BBCFBS,K
+play,7,1,zobrb001,12,CBCFX,8/F
+play,8,0,broxk001,00,,NP
+sub,heywj001,"Jason Heyward",1,4,9
+play,8,0,broxk001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,8,0,broxk001,11,..CBX,S7/L
+play,8,0,maldm001,22,BCC>F1B>X,63/G.1-2
+play,8,0,knebc001,00,,NP
+sub,wilka002,"Andy Wilkins",0,9,11
+play,8,0,wilka002,02,.CSS,K
+play,8,0,villj001,11,FBX,43/G
+play,8,1,contw001,00,,NP
+sub,thort001,"Tyler Thornburg",0,9,1
+play,8,1,contw001,32,.SBCBFBB,W
+play,8,1,baezj001,11,CBX,8/F
+play,8,1,rossd001,12,BFFS,K
+play,8,1,grimj002,00,,NP
+sub,fowld001,"Dexter Fowler",1,9,11
+play,8,1,fowld001,10,.BX,5/P
+play,9,0,genns001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,9,0,genns001,12,.BFFX,53/G
+play,9,0,florr003,00,,NP
+sub,pinam001,"Manny Pina",0,3,11
+play,9,0,pinam001,02,.CFFX,8/F
+play,9,0,pereh001,01,CX,HR/7/F
+play,9,0,cartc002,01,CX,S4/L-
+play,9,0,nieuk001,00,,NP
+sub,chapa001,"Aroldis Chapman",1,9,1
+play,9,0,nieuk001,00,,NP
+sub,elmoj001,"Jake Elmore",0,6,11
+play,9,0,elmoj001,00,..B,WP.1-2
+play,9,0,elmoj001,32,..B.BCFFBFB,W
+play,9,0,broxk001,01,FX,S51/G-.2-3;1-2
+play,9,0,maldm001,22,BSS*BC,K
+data,er,andec001,0
+data,er,marij001,1
+data,er,boyeb001,0
+data,er,scahr001,3
+data,er,knebc001,0
+data,er,thort001,0
+data,er,hammj002,0
+data,er,grimj002,0
+data,er,woodt004,1
+data,er,chapa001,0
+id,CHN201608170
+version,2
+info,visteam,MIL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/17
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,davig901
+info,ump1b,drakr901
+info,ump2b,torrc901
+info,ump3b,holbs901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,81
+info,winddir,torf
+info,windspeed,3
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,170
+info,attendance,40310
+info,wp,lestj001
+info,lp,nelsj004
+info,save,
+start,broxk001,"Keon Broxton",0,1,8
+start,arcio002,"Orlando Arcia",0,2,6
+start,villj001,"Jonathan Villar",0,3,5
+start,pereh001,"Hernan Perez",0,4,9
+start,cartc002,"Chris Carter",0,5,3
+start,genns001,"Scooter Gennett",0,6,4
+start,elmoj001,"Jake Elmore",0,7,7
+start,maldm001,"Martin Maldonado",0,8,2
+start,nelsj004,"Jimmy Nelson",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,solej001,"Jorge Soler",1,6,7
+start,heywj001,"Jason Heyward",1,7,9
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,broxk001,22,BFBFX,63/G
+play,1,0,arcio002,22,BFLBFFT,K
+play,1,0,villj001,32,SSBBBFC,K
+play,1,1,fowld001,32,CCBBBFFB,W
+play,1,1,bryak001,12,CBFH,HP.1-2
+play,1,1,rizza001,12,FBCX,8/F
+play,1,1,zobrb001,22,CBBCX,S9/G+.2-H;1-3
+play,1,1,russa002,12,CBFX,S4/L-.3-H;1-3
+play,1,1,solej001,22,BSBSX,HR/78/F.3-H;1-H
+play,1,1,heywj001,01,CX,D7/G
+play,1,1,rossd001,02,CSS,K
+play,1,1,lestj001,32,CBBCFBFFB,W
+play,1,1,fowld001,22,BCFBC,K
+play,2,0,pereh001,22,CSBBFFFX,43/G+
+play,2,0,cartc002,12,CCBX,S7/L
+play,2,0,genns001,02,FSS,K
+play,2,0,elmoj001,12,CBCX,S9/L.1-2
+play,2,0,maldm001,31,BCBBB,W.2-3;1-2
+play,2,0,nelsj004,21,BBCX,64(1)/FO/G
+play,2,1,bryak001,01,CH,HP
+play,2,1,rizza001,11,BCX,5/P
+play,2,1,zobrb001,00,X,S8/L+.1-2
+play,2,1,russa002,12,BSFX,64(1)3/GDP
+play,3,0,broxk001,12,CBFC,K
+play,3,0,arcio002,01,FX,1/BP
+play,3,0,villj001,32,TBBBFX,63/G
+play,3,1,solej001,22,CCBFBX,63/G
+play,3,1,heywj001,22,BBFFX,3/G
+play,3,1,rossd001,12,STBX,HR/7/F
+play,3,1,lestj001,12,CBFC,K
+play,4,0,pereh001,31,BBBCX,7/F
+play,4,0,cartc002,32,CBBSBT,K
+play,4,0,genns001,11,BCX,8/F
+play,4,1,fowld001,00,X,43/G
+play,4,1,bryak001,01,CX,3/L
+play,4,1,rizza001,21,BBFX,8/F
+play,5,0,elmoj001,32,CBFBBFFX,63/G
+play,5,0,maldm001,32,FBFBBFC,K
+play,5,0,nelsj004,12,CBFT,K
+play,5,1,zobrb001,12,CBCFS,K
+play,5,1,russa002,12,FBSX,7/L
+play,5,1,solej001,22,CBFBX,63/G
+play,6,0,broxk001,11,CBX,S7/L
+play,6,0,arcio002,00,>C,SB2
+play,6,0,arcio002,12,>C.BFN,SB3
+play,6,0,arcio002,12,>C.BFN.X,1/G-.3-H
+play,6,0,villj001,21,BCBX,9/F
+play,6,0,pereh001,00,X,8/F
+play,6,1,heywj001,00,,NP
+sub,cravt001,"Tyler Cravy",0,9,1
+play,6,1,heywj001,11,.BCX,9/L+
+play,6,1,rossd001,31,BBBFB,W
+play,6,1,lestj001,10,BX,7/F7LF
+play,6,1,fowld001,20,BBX,S9/F-.1-2
+play,6,1,bryak001,01,SX,8/F
+play,7,0,cartc002,01,SX,3/P
+play,7,0,genns001,22,CBFBX,63/G
+play,7,0,elmoj001,32,CBSBFBB,W
+play,7,0,maldm001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,7,0,maldm001,12,.CB1SFX,23/G-
+play,7,1,rizza001,00,,NP
+sub,torrc001,"Carlos Torres",0,9,1
+play,7,1,rizza001,02,.CSS,K
+play,7,1,zobrb001,01,CX,9/F
+play,7,1,russa002,22,BBFSS,K
+play,8,0,torrc001,00,,NP
+sub,florr003,"Ramon Flores",0,9,11
+play,8,0,florr003,32,.CFBBBFX,S7/G
+play,8,0,broxk001,12,CBSS,K
+play,8,0,arcio002,10,BX,9/F
+play,8,0,villj001,02,FF>FX,13/G-
+play,8,1,solej001,00,,NP
+sub,magnd001,"Damien Magnifico",0,9,1
+play,8,1,solej001,00,.X,S6/G
+play,8,1,heywj001,21,BBFX,7/F
+play,8,1,rossd001,30,B*BBB,W.1-2
+play,8,1,edwac001,00,,NP
+sub,baezj001,"Javier Baez",1,9,11
+play,8,1,baezj001,10,.*BX,53/G-.2-3;1-2
+play,8,1,fowld001,10,BX,43/G
+play,9,0,pereh001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,9,0,pereh001,00,,NP
+sub,woodt004,"Travis Wood",1,6,1
+play,9,0,pereh001,00,,NP
+sub,baezj001,"Javier Baez",1,9,4
+play,9,0,pereh001,02,...CFX,8/L
+play,9,0,cartc002,12,TCFBT,K
+play,9,0,genns001,12,FBSX,31/G
+data,er,nelsj004,6
+data,er,cravt001,0
+data,er,torrc001,0
+data,er,magnd001,0
+data,er,lestj001,1
+data,er,edwac001,0
+data,er,woodt004,0
+id,CHN201608180
+version,2
+info,visteam,MIL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/18
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,drakr901
+info,ump1b,torrc901
+info,ump2b,holbs901
+info,ump3b,davig901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,84
+info,winddir,unknown
+info,windspeed,9
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,201
+info,attendance,41407
+info,wp,arrij001
+info,lp,daviz001
+info,save,chapa001
+start,villj001,"Jonathan Villar",0,1,6
+start,genns001,"Scooter Gennett",0,2,4
+start,braur002,"Ryan Braun",0,3,7
+start,pereh001,"Hernan Perez",0,4,5
+start,cartc002,"Chris Carter",0,5,3
+start,nieuk001,"Kirk Nieuwenhuis",0,6,8
+start,maldm001,"Martin Maldonado",0,7,2
+start,florr003,"Ramon Flores",0,8,9
+start,daviz001,"Zach Davies",0,9,1
+start,szczm001,"Matt Szczur",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,9
+start,russa002,"Addison Russell",1,5,6
+start,solej001,"Jorge Soler",1,6,7
+start,contw001,"Willson Contreras",1,7,2
+start,baezj001,"Javier Baez",1,8,4
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,villj001,02,CCS,K
+play,1,0,genns001,12,BSFX,43/G
+play,1,0,braur002,12,BFCX,43/G
+play,1,1,szczm001,01,CX,8/F
+play,1,1,bryak001,22,CFBFFBX,S8/G
+play,1,1,rizza001,01,CX,D9/L.1-3
+play,1,1,zobrb001,31,CBBBX,3/G.3-H;2-3
+play,1,1,russa002,10,BX,S8/L.3-H
+play,1,1,solej001,32,C1BSB*B>C,K
+play,2,0,pereh001,11,BCX,8/L
+play,2,0,cartc002,00,X,8/F
+play,2,0,nieuk001,22,CBBFX,7/F
+play,2,1,contw001,12,FBFX,4/L-
+play,2,1,baezj001,12,CSBS,K
+play,2,1,arrij001,22,BBFSFFS,K
+play,3,0,maldm001,22,BCBFX,13/G
+play,3,0,florr003,11,FBX,8/F
+play,3,0,daviz001,31,BBBCB,W
+play,3,0,villj001,01,CX,8/F
+play,3,1,szczm001,12,BCFFX,S8/L-
+play,3,1,bryak001,00,X,HR/78/F.1-H
+play,3,1,rizza001,00,X,63/G
+play,3,1,zobrb001,31,BCBBB,W
+play,3,1,russa002,22,CBFFBFX,S7/F.1-2
+play,3,1,solej001,00,X,9/L-
+play,3,1,contw001,11,CB2X,D9/L.2-H;1-3
+play,3,1,baezj001,02,CFX,9/L
+play,4,0,genns001,00,X,7/F
+play,4,0,braur002,11,CBX,13/G
+play,4,0,pereh001,32,BBCCBB,W
+play,4,0,cartc002,12,SCB*B,SB2
+play,4,0,cartc002,32,SCB*B.*BB,W
+play,4,0,nieuk001,11,S*BX,HR/89/L.2-H;1-H
+play,4,0,maldm001,11,SBX,53/G
+play,4,1,arrij001,11,BCX,43/G
+play,4,1,szczm001,21,BSBX,D7/L
+play,4,1,bryak001,22,BSB+2SFFX,D7/L.2-H
+play,4,1,rizza001,12,BSCFFX,D9/L.2-H
+play,4,1,zobrb001,12,BCCC,K
+play,4,1,russa002,00,X,7/F
+play,5,0,florr003,31,BBCB*B,W
+play,5,0,daviz001,00,,NP
+sub,arcio002,"Orlando Arcia",0,9,11
+play,5,0,arcio002,12,.CSB+1,PO1(23)
+play,5,0,arcio002,32,.CSB+1.BBB,W
+play,5,0,villj001,32,BCS1BBS,K
+play,5,0,genns001,11,SBX,D8/L.1-3
+play,5,0,braur002,11,*BFX,63/G
+play,5,1,solej001,00,,NP
+sub,scahr001,"Rob Scahill",0,9,1
+play,5,1,solej001,32,.BCSBBC,K
+play,5,1,contw001,22,CSBBX,63/G
+play,5,1,baezj001,00,X,S9/L
+play,5,1,arrij001,01,FX,63/G
+play,6,0,pereh001,00,X,HR/78/F
+play,6,0,cartc002,32,BCFBBFB,W
+play,6,0,nieuk001,22,BCFBX,13/G-.1-2
+play,6,0,maldm001,12,CFBS,K
+play,6,0,florr003,10,BB,PB.2-3
+play,6,0,florr003,32,BB.BCCB,W
+play,6,0,scahr001,00,,NP
+sub,patts002,"Spencer Patton",1,9,1
+play,6,0,scahr001,00,,NP
+sub,broxk001,"Keon Broxton",0,9,11
+play,6,0,broxk001,32,..BSBBF>B,W.1-2
+play,6,0,villj001,21,BBS+1,OA/MREV
+com,"replay,6,villj001,MIL,davig901,CHI11,,N,M,CHN,A"
+com,"$when Keon Broxton was called safe at 1B on a"
+com,"pickoff attempt, Cubs manager Joe Maddon"
+com,"challenged the ruling; the call was upheld"
+com,"by replay"
+play,6,0,villj001,31,BBS+1*BB,W.3-H;2-3;1-2
+play,6,0,genns001,20,BBX,43/G
+play,6,1,szczm001,00,,NP
+sub,boyeb001,"Blaine Boyer",0,9,1
+play,6,1,szczm001,02,.FFX,43/G
+play,6,1,bryak001,31,BBBCX,HR/8/F
+play,6,1,rizza001,22,BCBSS,K
+play,6,1,zobrb001,32,BBBCCX,43/G
+play,7,0,braur002,00,X,8/F
+play,7,0,pereh001,01,CX,9/F
+play,7,0,cartc002,10,BX,8/L
+play,7,1,russa002,00,,NP
+sub,torrc001,"Carlos Torres",0,9,1
+play,7,1,russa002,10,.BX,7/F
+play,7,1,solej001,12,SFBFX,31/G-
+play,7,1,contw001,00,X,3/G-
+play,8,0,nieuk001,00,X,D9/L
+play,8,0,maldm001,01,CX,9/L.2-3
+play,8,0,florr003,00,X,31/G.3-H
+play,8,0,torrc001,00,,NP
+sub,pinam001,"Manny Pina",0,9,11
+play,8,0,pinam001,32,.BCBBFB,W
+play,8,0,villj001,00,,NP
+sub,szczm001,"Matt Szczur",1,1,7
+play,8,0,villj001,00,,NP
+sub,grimj002,"Justin Grimm",1,6,1
+play,8,0,villj001,00,,NP
+sub,fowld001,"Dexter Fowler",1,9,8
+play,8,0,villj001,10,...BX,S8/L.1-3
+play,8,0,genns001,11,BSX,3/G-
+play,8,1,baezj001,00,,NP
+sub,knebc001,"Corey Knebel",0,9,1
+play,8,1,baezj001,12,.FSFFBX,S7/L
+play,8,1,fowld001,21,1BC1B+11>X,8/F
+play,8,1,szczm001,32,BC11B+1SBB,W.1-2
+play,8,1,bryak001,22,BBFFX,S7/G+.2-H;1-2
+play,8,1,rizza001,12,CFBX,7/L
+play,8,1,zobrb001,01,CX,9/F
+play,9,0,braur002,00,,NP
+sub,chapa001,"Aroldis Chapman",1,6,1
+play,9,0,braur002,02,.CSS,K
+play,9,0,pereh001,32,CBSFBBFFFFFX,S7/L
+play,9,0,cartc002,00,>C,DI.1-2
+play,9,0,cartc002,12,>C.SBS,K
+play,9,0,nieuk001,11,CBB,PB.2-3
+play,9,0,nieuk001,22,CBB.FX,31/G
+data,er,daviz001,7
+data,er,scahr001,0
+data,er,boyeb001,1
+data,er,torrc001,0
+data,er,knebc001,1
+data,er,arrij001,5
+data,er,patts002,1
+data,er,grimj002,0
+data,er,chapa001,0
+id,CHN201608290
+version,2
+info,visteam,PIT
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/29
+info,number,0
+info,starttime,7:07PM
+info,daynight,night
+info,usedh,false
+info,umphome,gibsh902
+info,ump1b,knigb901
+info,ump2b,randt901
+info,ump3b,millb901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,seipb701
+info,temp,75
+info,winddir,fromlf
+info,windspeed,3
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,303
+info,attendance,38951
+info,wp,zastr001
+info,lp,lockj001
+info,save,
+start,harrj002,"Josh Harrison",0,1,4
+start,bellj005,"Josh Bell",0,2,3
+start,mccua001,"Andrew McCutchen",0,3,8
+start,polag001,"Gregory Polanco",0,4,9
+start,marts002,"Starling Marte",0,5,7
+start,freed001,"David Freese",0,6,5
+start,cervf001,"Francisco Cervelli",0,7,2
+start,mercj002,"Jordy Mercer",0,8,6
+start,braus002,"Steven Brault",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,solej001,"Jorge Soler",1,5,7
+start,heywj001,"Jason Heyward",1,6,9
+start,contw001,"Willson Contreras",1,7,2
+start,baezj001,"Javier Baez",1,8,6
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,harrj002,01,SX,53/G
+play,1,0,bellj005,31,BBCBB,W
+play,1,0,mccua001,10,B1X,9/F
+play,1,0,polag001,02,CFF>B,CS2(26)
+play,1,1,fowld001,22,CBCBX,S7/L
+play,1,1,bryak001,32,1SCBFB*BX,E1/TH/FO/G.1-3
+play,1,1,rizza001,32,BBBFFX,53/G.3-H(UR);1-2
+play,1,1,zobrb001,00,X,7/F
+play,1,1,solej001,22,SBFBC,K
+play,2,0,polag001,32,CSBBFBX,8/F
+play,2,0,marts002,11,CBX,4/P
+play,2,0,freed001,12,CCBS,K
+play,2,1,heywj001,12,CFBX,S9/L
+play,2,1,contw001,32,B1BBCCC,K
+play,2,1,baezj001,00,X,7/L
+play,2,1,arrij001,22,BFF*BX,S9/G-.1-2
+play,2,1,fowld001,00,X,9/F
+play,3,0,cervf001,21,BCBX,63/G
+play,3,0,mercj002,01,CX,63/G
+play,3,0,braus002,01,CX,13/G-
+play,3,1,bryak001,32,BBFSBB,W
+play,3,1,rizza001,31,BFBBB,W.1-2
+play,3,1,zobrb001,12,BCFC,K
+play,3,1,solej001,00,X,D7/F.2-H;1-3
+play,3,1,heywj001,10,BX,31/G-.3-H;2-3
+play,3,1,contw001,12,*BFFX,63/G
+play,4,0,harrj002,02,CSS,K
+play,4,0,bellj005,10,BX,HR/7/F
+play,4,0,mccua001,22,CBCFBX,53/G
+play,4,0,polag001,22,BCFBFX,31/G
+play,4,1,baezj001,12,CFBX,S7/L+
+play,4,1,arrij001,32,1BBSS1BFFFFFFFFS,K
+play,4,1,fowld001,11,CB1>X,53/G.1-3
+play,4,1,bryak001,00,H,HP
+play,4,1,rizza001,32,*BCCBFB>X,3/G
+play,5,0,marts002,01,CX,S9/L-
+play,5,0,freed001,12,CBS1>F1C,K
+play,5,0,cervf001,01,1C1>C,SB2.1-3(E2/TH2)
+play,5,0,cervf001,02,1C1>C.X,FC1/G/MREV.3XH(15261);B-2
+com,"replay,5,cervf001,PIT,millb901,CHI11,,N,M,PIT,P"
+com,"$when Starling Marte was called out at HP, Pirates"
+com,"manager Clint Hurdle challenged the ruling; the"
+com,"call was upheld by replay"
+play,5,0,mercj002,21,BBCX,43/G
+play,5,1,zobrb001,00,,NP
+sub,hughj001,"Jared Hughes",0,9,1
+play,5,1,zobrb001,00,.X,43/G-
+play,5,1,solej001,22,CBSBX,S7/G+
+play,5,1,heywj001,21,CBBX,43/G.1-2
+play,5,1,contw001,11,FBX,8/F
+play,6,0,hughj001,00,,NP
+sub,jasoj001,"John Jaso",0,9,11
+play,6,0,jasoj001,02,.CCX,63/G-
+play,6,0,harrj002,00,X,S9/L
+play,6,0,bellj005,21,*BB1F1>C,SB2
+play,6,0,bellj005,32,*BB1F1>C.BB,W
+play,6,0,mccua001,00,X,6/P/IF
+play,6,0,polag001,00,X,HR/7/F.2-H;1-H
+play,6,0,marts002,10,BX,53/G-
+play,6,1,baezj001,00,,NP
+sub,schua001,"A.J. Schugel",0,9,1
+play,6,1,baezj001,02,.LLFC,K
+play,6,1,arrij001,22,BFSFBS,K
+play,6,1,fowld001,12,SBCX,4/L-
+play,7,0,freed001,00,X,S4/G
+play,7,0,cervf001,32,F*BCBFB>B,W.1-2
+play,7,0,mercj002,20,BBX,15(2)/FO/G.1-2
+play,7,0,schua001,00,,NP
+sub,joycm001,"Matthew Joyce",0,9,11
+play,7,0,joycm001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,7,0,joycm001,02,..SFC,K
+play,7,0,harrj002,02,FFFFX,D7/L.2-H;1-H
+play,7,0,bellj005,12,C*BFFX,63/G
+play,7,1,bryak001,00,,NP
+sub,rivef001,"Felipe Rivero",0,2,1
+play,7,1,bryak001,00,,NP
+sub,rodrs002,"Sean Rodriguez",0,9,3
+play,7,1,bryak001,02,..FSFC,K
+play,7,1,rizza001,21,CBBX,4/L
+play,7,1,zobrb001,32,BBBCCB,W
+play,7,1,solej001,21,SBBX,7/F
+play,8,0,mccua001,00,,NP
+sub,patts002,"Spencer Patton",1,9,1
+play,8,0,mccua001,00,.X,S57/G
+play,8,0,polag001,21,CB1*B>B,CS2(26)
+play,8,0,polag001,32,CB1*B>B.FT,K
+play,8,0,marts002,32,BSBFBFX,S8/G+
+play,8,0,freed001,00,>B,SB2
+play,8,0,freed001,30,>B.BBB,W
+play,8,0,cervf001,11,BFX,9/F
+play,8,1,heywj001,00,,NP
+sub,felin001,"Neftali Feliz",0,2,1
+play,8,1,heywj001,01,.CX,D9/L+
+play,8,1,contw001,10,BX,HR/8/F+.2-H
+play,8,1,baezj001,32,BFBSBX,D8/L+
+play,8,1,patts002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,8,1,szczm001,22,.CBBCS,K
+play,8,1,fowld001,22,CBFBS,K
+play,8,1,bryak001,00,B,WP.2-3
+play,8,1,bryak001,30,B.BB*B,W
+play,8,1,rizza001,22,BBFT>S,K
+play,9,0,mercj002,00,,NP
+sub,penaf002,"Felix Pena",1,9,1
+play,9,0,mercj002,32,.BBFBFFFX,7/F
+play,9,0,rodrs002,32,CSBBBS,K
+play,9,0,harrj002,11,BFX,S5/BG
+play,9,0,felin001,00,,NP
+sub,fryee001,"Eric Fryer",0,2,11
+play,9,0,fryee001,02,.1CFFS,K
+play,9,1,zobrb001,00,,NP
+sub,watst001,"Tony Watson",0,2,1
+play,9,1,zobrb001,32,.BCBBFFX,9/F
+play,9,1,solej001,12,SFBX,HR/89/F
+play,9,1,heywj001,21,BBCX,4/P
+play,9,1,contw001,11,FBX,43/G
+play,10,0,mccua001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,10,0,mccua001,00,,NP
+sub,chapa001,"Aroldis Chapman",1,5,1
+play,10,0,mccua001,00,,NP
+sub,baezj001,"Javier Baez",1,8,4
+play,10,0,mccua001,00,,NP
+sub,russa002,"Addison Russell",1,9,6
+play,10,0,mccua001,12,....BFFS,K
+play,10,0,polag001,32,BBFBFFB,W
+play,10,0,marts002,02,SSS,K
+play,10,0,freed001,00,1X,53/G
+play,10,1,baezj001,00,,NP
+sub,lockj001,"Jeff Locke",0,2,1
+play,10,1,baezj001,02,.CSX,S8/L-
+play,10,1,russa002,12,1F1FBFFFS,K
+play,10,1,fowld001,01,C1X,S8/G.1-3
+play,10,1,bryak001,30,IIII,IW.1-2
+play,10,1,rizza001,22,FBBFFFX,3(B)2(3)/GDP/MREV
+com,"replay,10,rizza001,CHN,millb901,CHI11,,N,M,CHN,C"
+com,"replay,10,rizza001,CHN,millb901,CHI11,,N,M,CHN,A"
+com,"$when Javier Baez was called out at HP, Cubs"
+com,"manager Joe Maddon challenged the ruling and"
+com,"the out call at 1B; both calls were upheld"
+com,"by replay"
+play,11,0,cervf001,00,,NP
+sub,cahit001,"Trevor Cahill",1,5,1
+play,11,0,cervf001,10,.BX,8/F
+play,11,0,mercj002,21,BBFX,S9/G
+play,11,0,rodrs002,11,CBX,8/F
+play,11,0,harrj002,11,SBX,E4/G.1-3
+play,11,0,lockj001,01,C>X,S/G/BR.1X2(4)
+play,11,1,zobrb001,32,BBCBCC,K
+play,11,1,cahit001,00,,NP
+sub,rossd001,"David Ross",1,5,11
+play,11,1,rossd001,22,.BSBSX,8/F
+play,11,1,heywj001,21,BBCX,43/G-
+play,12,0,mccua001,00,,NP
+sub,grimj002,"Justin Grimm",1,5,1
+play,12,0,mccua001,00,.X,53/G
+play,12,0,polag001,22,BBCTS,K
+play,12,0,marts002,02,CSX,3/P3F-
+play,12,1,contw001,00,X,53/G
+play,12,1,baezj001,02,CFFX,T9/L+
+play,12,1,russa002,22,CBBSFFFX,7/F/DP/UREV.3XH(72)
+com,"replay,12,russa002,CHN,millb901,CHI11,,N,U,,P"
+com,"$when Javier Baez was called out at HP, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was upheld by replay"
+play,13,0,freed001,00,,NP
+sub,zastr001,"Rob Zastryzny",1,5,1
+play,13,0,freed001,10,.BX,S1/G
+play,13,0,cervf001,10,BX,S7/G+.1-2
+play,13,0,mercj002,32,B*BBCCB,W.2-3;1-2
+play,13,0,rodrs002,32,BBBCTS,K
+play,13,0,harrj002,10,BX,7/L+/SF.3-H
+play,13,0,lockj001,02,SCC,K
+play,13,1,fowld001,31,CBBBX,S7/G
+play,13,1,bryak001,32,FFBBFF*BX,S9/L.1-3
+play,13,1,rizza001,01,FX,S9/G.3-H;1-3
+play,13,1,zobrb001,30,IIII,IW.1-2
+play,13,1,zastr001,00,,NP
+sub,montm001,"Miguel Montero",1,5,11
+play,13,1,montm001,12,.SFFFBX,S7/L.3-H;2-3;1-2
+data,er,braus002,2
+data,er,hughj001,0
+data,er,schua001,0
+data,er,rivef001,0
+data,er,felin001,2
+data,er,watst001,1
+data,er,lockj001,2
+data,er,arrij001,6
+data,er,woodt004,0
+data,er,patts002,0
+data,er,penaf002,0
+data,er,chapa001,0
+data,er,cahit001,0
+data,er,grimj002,0
+data,er,zastr001,1
+id,CHN201608300
+version,2
+info,visteam,PIT
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/30
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,knigb901
+info,ump1b,randt901
+info,ump2b,millb901
+info,ump3b,gibsh902
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,75
+info,winddir,fromlf
+info,windspeed,1
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,156
+info,attendance,38174
+info,wp,hendk001
+info,lp,kuhlc001
+info,save,chapa001
+start,harrj002,"Josh Harrison",0,1,4
+start,bellj005,"Josh Bell",0,2,3
+start,mccua001,"Andrew McCutchen",0,3,8
+start,polag001,"Gregory Polanco",0,4,9
+start,marts002,"Starling Marte",0,5,7
+start,freed001,"David Freese",0,6,5
+start,cervf001,"Francisco Cervelli",0,7,2
+start,mercj002,"Jordy Mercer",0,8,6
+start,kuhlc001,"Chad Kuhl",0,9,1
+start,baezj001,"Javier Baez",1,1,4
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,solej001,"Jorge Soler",1,4,7
+start,heywj001,"Jason Heyward",1,5,9
+start,russa002,"Addison Russell",1,6,6
+start,montm001,"Miguel Montero",1,7,2
+start,szczm001,"Matt Szczur",1,8,8
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,harrj002,21,CBBX,9/F
+play,1,0,bellj005,21,CBBX,43/G+
+play,1,0,mccua001,32,CBBBCX,4/P
+play,1,1,baezj001,02,FSH,HP
+play,1,1,bryak001,00,1X,7/F
+play,1,1,rizza001,22,BBFFX,HR/9/L.1-H
+play,1,1,solej001,22,BSBCC,K
+play,1,1,heywj001,21,BCBX,31/G+
+play,2,0,polag001,22,CBBSX,4/P
+play,2,0,marts002,22,BBTCX,63/G+
+play,2,0,freed001,32,CSBBBS,K
+play,2,1,russa002,32,CSFFBBBFB,W
+play,2,1,montm001,10,B1C,SB2
+play,2,1,montm001,32,B1C.B2BCFFX,S7/L.2-H;BX2(14)
+play,2,1,szczm001,11,MBX,8/F
+play,2,1,hendk001,11,BSX,53/G
+play,3,0,cervf001,12,CCBX,63/G
+play,3,0,mercj002,11,CBX,63/G
+play,3,0,kuhlc001,22,BBCSC,K
+play,3,1,baezj001,21,BSBX,7/L+
+play,3,1,bryak001,32,BFBBSFFFFFX,D3/P-
+play,3,1,rizza001,01,FX,43/G.2-3
+play,3,1,solej001,32,BSB*BCB,W
+play,3,1,heywj001,20,BBX,8/F
+play,4,0,harrj002,32,CFBFBFBFB,W
+play,4,0,bellj005,01,S1,PO1(13)
+play,4,0,bellj005,22,S1.CBBX,53/G
+play,4,0,mccua001,00,X,8/F
+play,4,1,russa002,22,BSBSS,K
+play,4,1,montm001,22,BCBCFS,K
+play,4,1,szczm001,02,CFX,S8/G+
+play,4,1,hendk001,10,BX,13/G
+play,5,0,polag001,22,CBBCX,S8/L
+play,5,0,marts002,12,BCCX,64(1)/FO/G
+play,5,0,freed001,01,C11>B,CS2(24)
+play,5,0,freed001,12,C11>B.FC,K
+play,5,1,baezj001,02,CFS,K
+play,5,1,bryak001,12,BCSC,K
+play,5,1,rizza001,00,X,9/F
+play,6,0,cervf001,21,CBBX,9/F
+play,6,0,mercj002,12,CBCFX,63/G
+play,6,0,kuhlc001,00,,NP
+sub,jasoj001,"John Jaso",0,9,11
+play,6,0,jasoj001,00,.X,D9/L
+play,6,0,harrj002,20,BBX,8/F
+play,6,1,solej001,00,,NP
+sub,schua001,"A.J. Schugel",0,9,1
+play,6,1,solej001,11,.CBX,S9/G
+play,6,1,heywj001,02,CFS,K
+play,6,1,russa002,31,BBBCX,13/G.1-2
+play,6,1,montm001,12,FFFBFX,43/G
+play,7,0,bellj005,02,CFC,K
+play,7,0,mccua001,32,BFCBBX,S7/L
+play,7,0,polag001,12,SC*B1X,46(1)/FO/G
+play,7,0,marts002,10,B1>S,SB2
+play,7,0,marts002,11,B1>S.X,9/L
+play,7,1,szczm001,00,X,7/L+
+play,7,1,hendk001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,9,11
+play,7,1,zobrb001,22,.CBFBFFFX,6/P
+play,7,1,baezj001,32,BBBCFX,13/G+
+play,8,0,freed001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,8,0,freed001,22,.BBCSX,43/G
+play,8,0,cervf001,21,BSBX,8/F
+play,8,0,mercj002,32,CBBBSFFX,D8/L
+play,8,0,schua001,00,,NP
+sub,joycm001,"Matthew Joyce",0,9,11
+play,8,0,joycm001,32,.CBBFBFX,8/L
+play,8,1,bryak001,00,,NP
+sub,hughj001,"Jared Hughes",0,9,1
+play,8,1,bryak001,21,.CBBX,8/F
+play,8,1,rizza001,12,FBFS,K
+play,8,1,solej001,30,BBBB,W
+play,8,1,heywj001,01,1CX,3/G
+play,9,0,harrj002,00,,NP
+sub,chapa001,"Aroldis Chapman",1,4,1
+play,9,0,harrj002,00,,NP
+sub,szczm001,"Matt Szczur",1,8,7
+play,9,0,harrj002,00,,NP
+sub,fowld001,"Dexter Fowler",1,9,8
+play,9,0,harrj002,22,...BCBFS,K
+play,9,0,bellj005,22,SFFBBX,43/G
+play,9,0,mccua001,01,CX,8/F
+data,er,kuhlc001,3
+data,er,schua001,0
+data,er,hughj001,0
+data,er,hendk001,0
+data,er,edwac001,0
+data,er,chapa001,0
+id,CHN201608310
+version,2
+info,visteam,PIT
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/08/31
+info,number,0
+info,starttime,7:09PM
+info,daynight,night
+info,usedh,false
+info,umphome,randt901
+info,ump1b,millb901
+info,ump2b,woodt901
+info,ump3b,knigb901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,70
+info,winddir,fromlf
+info,windspeed,17
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,228
+info,attendance,38137
+info,wp,hammj002
+info,lp,voger001
+info,save,chapa001
+start,harrj002,"Josh Harrison",0,1,4
+start,bellj005,"Josh Bell",0,2,3
+start,mccua001,"Andrew McCutchen",0,3,8
+start,polag001,"Gregory Polanco",0,4,9
+start,marts002,"Starling Marte",0,5,7
+start,cervf001,"Francisco Cervelli",0,6,2
+start,rodrs002,"Sean Rodriguez",0,7,5
+start,mercj002,"Jordy Mercer",0,8,6
+start,voger001,"Ryan Vogelsong",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,solej001,"Jorge Soler",1,4,7
+start,heywj001,"Jason Heyward",1,5,9
+start,russa002,"Addison Russell",1,6,6
+start,lastt001,"Tommy La Stella",1,7,4
+start,contw001,"Willson Contreras",1,8,2
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,harrj002,22,CFBFBX,E6/G-
+play,1,0,bellj005,20,1B1BX,7/L+
+play,1,0,mccua001,10,*B1X,54(1)3/GDP
+play,1,1,fowld001,32,BFBCBC,K
+play,1,1,bryak001,01,FX,HR/7/F
+play,1,1,rizza001,12,CBCX,53/G
+play,1,1,solej001,32,BBCCFFBX,4/P
+play,2,0,polag001,12,CBSC,K
+play,2,0,marts002,02,MSX,D9/L-
+play,2,0,cervf001,11,CBX,63/G-.2-3
+play,2,0,rodrs002,22,S*BCF*BX,5/L+
+play,2,1,heywj001,12,CSBX,7/F
+play,2,1,russa002,11,FBX,63/G
+play,2,1,lastt001,10,BX,43/G
+play,3,0,mercj002,22,BFCFBC,K
+play,3,0,voger001,02,CFC,K
+play,3,0,harrj002,22,MSBBX,53/G
+play,3,1,contw001,22,SFBBC,K
+play,3,1,hammj002,12,FFBFX,3/G
+play,3,1,fowld001,32,BSFBBC,K
+play,4,0,bellj005,11,CBX,5/P5F
+play,4,0,mccua001,01,CX,63/G+
+play,4,0,polag001,32,BFFBBX,T9/L
+play,4,0,marts002,12,SSFBX,43/G-
+play,4,1,bryak001,10,BX,S8/L+
+play,4,1,rizza001,00,B,WP.1-2
+play,4,1,rizza001,11,B.SX,3/G.2-3
+play,4,1,solej001,21,CB*BX,53/G
+play,4,1,heywj001,31,BCB*BB,W
+play,4,1,russa002,01,CX,S7/L.3-H;1-2
+play,4,1,lastt001,01,CX,43/G
+play,5,0,cervf001,20,BBX,7/L
+play,5,0,rodrs002,31,CBBBB,W
+play,5,0,mercj002,02,CFF>X,9/L
+play,5,0,voger001,32,B1FCB*B>B,W.1-2
+play,5,0,harrj002,11,BFX,S54/G.2-H;1-2
+play,5,0,bellj005,32,SFF*BBB*B,W.2-3;1-2
+play,5,0,mccua001,22,FSB*BFS,K
+play,5,1,contw001,21,BBCX,53/G+
+play,5,1,hammj002,01,SX,63/G
+play,5,1,fowld001,21,BCBX,T9/L+
+play,5,1,bryak001,30,BBBB,W
+play,5,1,rizza001,22,S*BT*BX,1/P
+play,6,0,polag001,22,FBFBT,K
+play,6,0,marts002,01,LX,9/F
+play,6,0,cervf001,32,BBBCFC,K
+play,6,1,solej001,01,SX,D8/L+
+play,6,1,heywj001,00,X,S8/L.2-H
+play,6,1,russa002,32,11S*BBBFFB,W.1-2
+play,6,1,lastt001,00,,NP
+sub,basta001,"Antonio Bastardo",0,9,1
+play,6,1,lastt001,00,,NP
+sub,baezj001,"Javier Baez",1,7,11
+play,6,1,baezj001,10,..BX,6/P/IF
+play,6,1,contw001,01,SS,WP.2-3;1-2
+play,6,1,contw001,02,SS.N,BK.3-H;2-3
+play,6,1,contw001,02,SS.N.X,D7/L+.3-H
+play,6,1,hammj002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,6,1,szczm001,30,.*B*B*BB,W
+play,6,1,fowld001,11,*BCX,9/F
+play,6,1,bryak001,22,BCSFFBS,K
+play,7,0,rodrs002,00,,NP
+sub,cahit001,"Trevor Cahill",1,4,1
+play,7,0,rodrs002,00,,NP
+sub,baezj001,"Javier Baez",1,7,4
+play,7,0,rodrs002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,7
+play,7,0,rodrs002,22,...BBCFS,K
+play,7,0,mercj002,21,CBBX,S5/G
+play,7,0,basta001,00,,NP
+sub,joycm001,"Matthew Joyce",0,9,11
+play,7,0,joycm001,31,.C*BBBB,W.1-2
+play,7,0,harrj002,21,BBCX,S7/G.2-3;1-2
+play,7,0,bellj005,00,,NP
+sub,grimj002,"Justin Grimm",1,4,1
+play,7,0,bellj005,32,.B*BCFBC,K
+play,7,0,mccua001,32,CCB*BB>F>B,W.3-H;2-3;1-2
+play,7,0,polag001,00,X,6!/P
+play,7,1,rizza001,00,,NP
+sub,nicaj001,"Juan Nicasio",0,9,1
+play,7,1,rizza001,32,.CBBCBFB,W
+play,7,1,grimj002,00,,NP
+sub,montm001,"Miguel Montero",1,4,11
+play,7,1,montm001,02,.CCS,K
+play,7,1,heywj001,00,X,S8/L.1-3
+play,7,1,russa002,12,1BCFX,8/F/SF.3-H
+play,7,1,baezj001,32,BBCBS>X,63/G
+play,8,0,marts002,00,,NP
+sub,woodt004,"Travis Wood",1,4,1
+play,8,0,marts002,12,.CFFBS,K
+play,8,0,cervf001,32,BFBBFX,D7/L
+play,8,0,rodrs002,32,CBBTBB,W
+play,8,0,mercj002,22,CBFBX,D7/L+.2-H;1-H
+play,8,0,nicaj001,00,,NP
+sub,freed001,"David Freese",0,9,11
+play,8,0,freed001,00,,NP
+sub,penaf002,"Felix Pena",1,4,1
+play,8,0,freed001,32,..BBBCFFFB,W
+play,8,0,harrj002,00,,NP
+sub,hansa001,"Alen Hanson",0,9,12
+play,8,0,harrj002,02,.CTS,K+PO2(E2/TH).2-3;1-2
+play,8,0,bellj005,22,BFF*BX,43/G
+play,8,1,contw001,00,,NP
+sub,hughj001,"Jared Hughes",0,9,1
+play,8,1,contw001,11,.BFX,13/G-
+play,8,1,szczm001,32,BFBBSB,W
+play,8,1,fowld001,00,X,7/L
+play,8,1,bryak001,00,1X,6/L
+play,9,0,mccua001,00,,NP
+sub,chapa001,"Aroldis Chapman",1,4,1
+play,9,0,mccua001,02,.FCFX,43/G
+play,9,0,polag001,12,CBSFFS,K
+play,9,0,marts002,00,X,S9/L
+play,9,0,cervf001,01,FB,WP.1-2
+play,9,0,cervf001,11,FB.B,WP.2-3
+play,9,0,cervf001,22,FB.B.SX,S9/L.3-H
+play,9,0,rodrs002,10,BB,WP.1-2
+play,9,0,rodrs002,30,BB.BB,W
+play,9,0,mercj002,22,CSFFFFBBFFS,K
+data,er,voger001,5
+data,er,basta001,0
+data,er,nicaj001,1
+data,er,hughj001,0
+data,er,hammj002,1
+data,er,cahit001,1
+data,er,grimj002,0
+data,er,woodt004,2
+data,er,penaf002,0
+data,er,chapa001,1
+id,CHN201609010
+version,2
+info,visteam,SFN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/01
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,hamaa901
+info,ump1b,hallt901
+info,ump2b,belld901
+info,ump3b,cuzzp901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,68
+info,winddir,fromlf
+info,windspeed,15
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,174
+info,attendance,38536
+info,wp,smitj002
+info,lp,strih001
+info,save,edwac001
+start,spand001,"Denard Span",0,1,8
+start,pagaa001,"Angel Pagan",0,2,7
+start,poseb001,"Buster Posey",0,3,2
+start,pench001,"Hunter Pence",0,4,9
+start,crawb001,"Brandon Crawford",0,5,6
+start,panij002,"Joe Panik",0,6,4
+start,nunee002,"Eduardo Nunez",0,7,5
+start,beltb001,"Brandon Belt",0,8,3
+start,samaj001,"Jeff Samardzija",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,heywj001,"Jason Heyward",1,5,9
+start,russa002,"Addison Russell",1,6,6
+start,coghc001,"Chris Coghlan",1,7,7
+start,rossd001,"David Ross",1,8,2
+start,montm002,"Mike Montgomery",1,9,1
+play,1,0,spand001,02,CCX,D9/L
+play,1,0,pagaa001,00,X,43/G.2-3
+play,1,0,poseb001,22,FBBFX,43/G
+play,1,0,pench001,10,BX,HR/78/F.3-H
+play,1,0,crawb001,31,BBBCX,4/L
+play,1,1,fowld001,32,CBFFFFBFFBFFB,W
+play,1,1,bryak001,02,FCB,WP.1-2
+play,1,1,bryak001,12,FCB.FFX,S9/L-.2-H
+play,1,1,rizza001,02,CFFX,36(1)/FO/G
+play,1,1,zobrb001,22,BBCCX,S7/L.1-2
+play,1,1,heywj001,12,CFBX,S7/L.2-H;1-3
+play,1,1,russa002,22,BBFFS,K
+play,1,1,coghc001,00,X,D9/G.3-H;1-3
+play,1,1,rossd001,30,IIII,IW
+play,1,1,montm002,22,FBBTS,K
+play,2,0,panij002,01,CH,HP
+play,2,0,nunee002,11,BFX,13/G-.1-2
+play,2,0,beltb001,21,BBCB,WP.2-3
+play,2,0,beltb001,32,BBCB.SB,W
+play,2,0,samaj001,01,S*B,WP.1-2
+play,2,0,samaj001,11,S*B.X,8/L/SF.3-H
+play,2,0,spand001,30,BBBB,W
+play,2,0,pagaa001,11,BSX,43/G
+play,2,1,fowld001,21,BCBX,7/L
+play,2,1,bryak001,00,X,9/F
+play,2,1,rizza001,21,CBBX,53/G
+play,3,0,poseb001,32,BFBFBB,W
+play,3,0,pench001,00,X,S9/G.1-2
+play,3,0,crawb001,02,SCX,14(1)/FO/G.2-H(UR)(E4/TH)
+play,3,0,panij002,00,X,3(B)63(1)/GDP
+play,3,1,zobrb001,32,CBBBSFC,K
+play,3,1,heywj001,00,X,3/G
+play,3,1,russa002,11,BSX,53/G
+play,4,0,nunee002,11,CBX,3/G
+play,4,0,beltb001,20,BBX,3/L
+play,4,0,samaj001,12,CBSS,K
+play,4,1,coghc001,02,FFX,7/F
+play,4,1,rossd001,32,BBCCBFFB,W
+play,4,1,montm002,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,4,1,lastt001,02,.CFX,7/L
+play,4,1,fowld001,12,CBCX,S8/G.1-3
+play,4,1,bryak001,10,1BX,8/F
+play,5,0,spand001,00,,NP
+sub,zastr001,"Rob Zastryzny",1,9,1
+play,5,0,spand001,11,.CBX,6/P
+play,5,0,pagaa001,02,CSX,143/G
+play,5,0,poseb001,10,BX,43/G
+play,5,1,rizza001,00,,NP
+sub,osicj001,"Josh Osich",0,9,1
+play,5,1,rizza001,21,.CBBX,13/G
+play,5,1,zobrb001,21,BCBX,43/G
+play,5,1,heywj001,12,CFBT,K
+play,6,0,pench001,21,BBCX,63/G
+play,6,0,crawb001,00,X,3/BG
+play,6,0,panij002,12,BCFFC,K
+play,6,1,russa002,00,,NP
+sub,kontg001,"George Kontos",0,9,1
+play,6,1,russa002,02,.SFT,K
+play,6,1,coghc001,32,BSFBBS,K
+play,6,1,rossd001,01,CX,S7/G
+play,6,1,zastr001,00,,NP
+sub,solej001,"Jorge Soler",1,9,11
+play,6,1,solej001,22,.CBBSS,K
+play,7,0,nunee002,00,,NP
+sub,smitj002,"Joe Smith",1,9,1
+play,7,0,nunee002,12,.CBSFX,63/G
+play,7,0,beltb001,12,CBSS,K
+play,7,0,kontg001,00,,NP
+sub,parkj002,"Jarrett Parker",0,9,11
+play,7,0,parkj002,12,.CBCS,K
+play,7,1,fowld001,00,,NP
+sub,strih001,"Hunter Strickland",0,9,1
+play,7,1,fowld001,12,.CFBX,S1/L
+play,7,1,bryak001,32,CBBF1B>B,W.1-2
+play,7,1,rizza001,00,,NP
+sub,smitw002,"Will Smith",0,9,1
+play,7,1,rizza001,22,.CBF*BFS,K
+play,7,1,zobrb001,11,C*B>C,SB3
+play,7,1,zobrb001,32,C*B>C.BF*B*B,W.1-2
+play,7,1,heywj001,22,BBFFX,4/P
+play,7,1,russa002,00,,NP
+sub,gearc001,"Cory Gearrin",0,9,1
+play,7,1,russa002,01,.CX,S7/L-.3-H;2-H;1-2
+play,7,1,coghc001,00,,NP
+sub,reynm002,"Matt Reynolds",0,9,1
+play,7,1,coghc001,00,,NP
+sub,baezj001,"Javier Baez",1,7,11
+play,7,1,baezj001,12,..SBFX,6/L
+play,8,0,spand001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,8,0,spand001,00,,NP
+sub,baezj001,"Javier Baez",1,7,4
+play,8,0,spand001,32,..CBBBCFS,K
+play,8,0,pagaa001,00,X,6/P
+play,8,0,poseb001,00,X,63/G
+play,8,1,rossd001,12,FFBX,63/G
+play,8,1,smitj002,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,8,1,szczm001,12,.BCLFX,63/G
+play,8,1,fowld001,32,CBFFBBFX,3/P3F
+play,9,0,pench001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,9,0,pench001,22,.CFBBS,K
+play,9,0,crawb001,12,CCFBFX,63/G
+play,9,0,panij002,01,CX,53/G
+data,er,samaj001,3
+data,er,osicj001,0
+data,er,kontg001,0
+data,er,strih001,2
+data,er,smitw002,0
+data,er,gearc001,0
+data,er,reynm002,0
+data,er,montm002,3
+data,er,zastr001,0
+data,er,smitj002,0
+data,er,edwac001,0
+id,CHN201609020
+version,2
+info,visteam,SFN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/02
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,hallt901
+info,ump1b,belld901
+info,ump2b,cuzzp901
+info,ump3b,hamaa901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,73
+info,winddir,fromcf
+info,windspeed,11
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,157
+info,attendance,40818
+info,wp,lestj001
+info,lp,suara001
+info,save,
+start,spand001,"Denard Span",0,1,8
+start,pagaa001,"Angel Pagan",0,2,7
+start,poseb001,"Buster Posey",0,3,3
+start,pench001,"Hunter Pence",0,4,9
+start,crawb001,"Brandon Crawford",0,5,6
+start,nunee002,"Eduardo Nunez",0,6,5
+start,panij002,"Joe Panik",0,7,4
+start,browt002,"Trevor Brown",0,8,2
+start,suara001,"Albert Suarez",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,coghc001,"Chris Coghlan",1,5,7
+start,heywj001,"Jason Heyward",1,6,9
+start,baezj001,"Javier Baez",1,7,6
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,spand001,01,CX,43/G-
+play,1,0,pagaa001,31,CBBBX,9/F
+play,1,0,poseb001,30,BBBB,W
+play,1,0,pench001,11,CBX,9/F
+play,1,1,fowld001,22,CBBSFX,43/G-
+play,1,1,bryak001,02,CFX,53/G
+play,1,1,rizza001,01,FX,8/L
+play,2,0,crawb001,22,SBFBFFX,3/L
+play,2,0,nunee002,02,CSX,1/L
+play,2,0,panij002,12,BSFS,K
+play,2,1,zobrb001,22,BCFBX,9/F
+play,2,1,coghc001,11,BCX,43/G
+play,2,1,heywj001,20,BBX,63/G
+play,3,0,browt002,22,CFBBX,7/L
+play,3,0,suara001,01,CX,31/G
+play,3,0,spand001,22,CBFBX,63/G-
+play,3,1,baezj001,32,BCBBFFFX,D9/G
+play,3,1,rossd001,11,BSX,D7/L.2-H
+play,3,1,lestj001,11,LBX,14/BG/SH.2-3
+play,3,1,fowld001,10,BX,S7/L-.3-H
+play,3,1,bryak001,32,BBTC*BB,W.1-2
+play,3,1,rizza001,32,BSCBBFFX,8/L
+play,3,1,zobrb001,21,BCBX,43/G-
+play,4,0,pagaa001,11,BCX,8/F
+play,4,0,poseb001,02,FSS,K
+play,4,0,pench001,12,SSBS,K
+play,4,1,coghc001,01,CX,7/F
+play,4,1,heywj001,12,CFBS,K
+play,4,1,baezj001,12,SBCFFFS,K
+play,5,0,crawb001,01,SX,5/L
+play,5,0,nunee002,20,BBX,3/P3F-
+play,5,0,panij002,11,FBX,43/G
+play,5,1,rossd001,22,BFFBFS,K
+play,5,1,lestj001,12,SFFFFBX,8/F
+play,5,1,fowld001,31,BBFBB,W
+play,5,1,bryak001,00,X,5/L+
+play,6,0,browt002,00,X,63/G
+play,6,0,suara001,00,,NP
+sub,tomlk001,"Kelby Tomlinson",0,9,11
+play,6,0,tomlk001,11,.CBX,8/L
+play,6,0,spand001,12,FBFX,6/L
+play,6,1,rizza001,00,,NP
+sub,okers001,"Steven Okert",0,9,1
+play,6,1,rizza001,12,.BCFFFX,S8/L
+play,6,1,zobrb001,32,BBCBCFFB,W.1-2
+play,6,1,coghc001,00,,NP
+sub,szczm001,"Matt Szczur",1,5,11
+play,6,1,szczm001,02,.SFX,4/P-/IF
+play,6,1,heywj001,22,BBCFS,K
+play,6,1,baezj001,00,,NP
+sub,gearc001,"Cory Gearrin",0,9,1
+play,6,1,baezj001,02,.SSS,K
+play,7,0,pagaa001,00,,NP
+sub,szczm001,"Matt Szczur",1,5,7
+play,7,0,pagaa001,00,.X,6/P
+play,7,0,poseb001,01,FX,63/G
+play,7,0,pench001,12,FSBX,HR/7/F
+play,7,0,crawb001,11,BSX,D8/G
+play,7,0,nunee002,10,*BX,5/L+
+play,7,1,rossd001,12,FCFBS,K
+play,7,1,lestj001,01,CX,63/G
+play,7,1,fowld001,32,BSBBFFX,8/F
+play,8,0,panij002,01,CX,3/G
+play,8,0,browt002,00,X,D7/L
+play,8,0,gearc001,00,,NP
+sub,willm008,"Mac Williamson",0,9,11
+play,8,0,willm008,00,.X,5/P
+play,8,0,spand001,00,X,43/G
+play,8,1,bryak001,00,,NP
+sub,romos001,"Sergio Romo",0,9,1
+play,8,1,bryak001,11,.BFX,7/F
+play,8,1,rizza001,02,CFFX,D9/G
+play,8,1,zobrb001,30,BBII,IW
+play,8,1,szczm001,00,,NP
+sub,montm001,"Miguel Montero",1,5,11
+play,8,1,montm001,00,,NP
+sub,osicj001,"Josh Osich",0,9,1
+play,8,1,montm001,00,,NP
+sub,russa002,"Addison Russell",1,5,11
+play,8,1,russa002,30,...BBBB,W.2-3;1-2
+play,8,1,heywj001,02,CFX,4/L/DP.1X1(43)
+play,9,0,pagaa001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,9,0,pagaa001,00,,NP
+sub,russa002,"Addison Russell",1,5,6
+play,9,0,pagaa001,00,,NP
+sub,baezj001,"Javier Baez",1,7,4
+play,9,0,pagaa001,21,...BBCX,43/G-
+play,9,0,poseb001,22,FBBSX,43/G
+play,9,0,pench001,32,CBSBBB,W
+play,9,0,crawb001,12,CBSC,K
+data,er,suara001,2
+data,er,okers001,0
+data,er,gearc001,0
+data,er,romos001,0
+data,er,osicj001,0
+data,er,lestj001,1
+id,CHN201609030
+version,2
+info,visteam,SFN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/03
+info,number,0
+info,starttime,1:22PM
+info,daynight,day
+info,usedh,false
+info,umphome,belld901
+info,ump1b,cuzzp901
+info,ump2b,hamaa901
+info,ump3b,hallt901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,71
+info,winddir,rtol
+info,windspeed,9
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,193
+info,attendance,41250
+info,wp,bumgm001
+info,lp,arrij001
+info,save,garcj002
+start,spand001,"Denard Span",0,1,8
+start,pagaa001,"Angel Pagan",0,2,7
+start,poseb001,"Buster Posey",0,3,2
+start,pench001,"Hunter Pence",0,4,9
+start,crawb001,"Brandon Crawford",0,5,6
+start,panij002,"Joe Panik",0,6,4
+start,beltb001,"Brandon Belt",0,7,3
+start,nunee002,"Eduardo Nunez",0,8,5
+start,bumgm001,"Madison Bumgarner",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,3
+start,zobrb001,"Ben Zobrist",1,3,9
+start,russa002,"Addison Russell",1,4,6
+start,contw001,"Willson Contreras",1,5,2
+start,baezj001,"Javier Baez",1,6,4
+start,szczm001,"Matt Szczur",1,7,7
+start,arrij001,"Jake Arrieta",1,8,1
+start,lastt001,"Tommy La Stella",1,9,5
+play,1,0,spand001,02,CFFC,K
+play,1,0,pagaa001,12,CFBX,D9/L
+play,1,0,poseb001,02,FFS,K
+play,1,0,pench001,22,BBFCX,E5/TH/G.2-H(NR)(UR)
+play,1,0,crawb001,00,X,6(1)/FO/G
+play,1,1,fowld001,21,CBBX,53/G
+play,1,1,bryak001,00,X,7/F+
+play,1,1,zobrb001,11,BCX,E3/P
+play,1,1,russa002,32,C*BSF1BB>S,K
+play,2,0,panij002,11,CBX,9/L+
+play,2,0,beltb001,02,CSS,K
+play,2,0,nunee002,01,CX,31/G
+play,2,1,contw001,32,BBBCCFFFFX,D7/L+
+play,2,1,baezj001,11,BFX,53/G
+play,2,1,szczm001,12,CF*BS,K
+play,2,1,arrij001,22,SBBSS,K
+play,3,0,bumgm001,32,CCBBFFBFB,W
+play,3,0,spand001,32,*BSSBBC,K
+play,3,0,pagaa001,01,FX,7/F
+play,3,0,poseb001,22,*BFCFBX,13/G
+play,3,1,lastt001,12,CBFFS,K
+play,3,1,fowld001,10,BX,53/G
+play,3,1,bryak001,10,BX,8/F
+play,4,0,pench001,02,CCFS,K
+play,4,0,crawb001,21,BCBX,43/G
+play,4,0,panij002,12,CBTX,S8/L-
+play,4,0,beltb001,00,1B,WP.1-2
+play,4,0,beltb001,32,1B.BSBSFB,W+PB.2-3
+play,4,0,nunee002,20,B1BX,S9/G+.3-H;1-2
+play,4,0,bumgm001,02,CCFX,64(1)/FO/G
+play,4,1,zobrb001,02,CFFC,K
+play,4,1,russa002,02,FCC,K
+play,4,1,contw001,01,CX,53/G-
+play,5,0,spand001,22,BBFFX,43/G
+play,5,0,pagaa001,31,BBBCX,5/P5F
+play,5,0,poseb001,01,CX,63/G
+play,5,1,baezj001,12,CCBX,S7/L+
+play,5,1,szczm001,22,FBFBFFF>C,K+SB2
+play,5,1,arrij001,00,X,S5/G-.2-H
+play,5,1,lastt001,00,,NP
+sub,solej001,"Jorge Soler",1,9,11
+play,5,1,solej001,02,.CSS,K
+play,5,1,fowld001,12,FFBFN,BK.1-2
+play,5,1,fowld001,12,FFBFN.S,K
+play,6,0,pench001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,3,4
+play,6,0,pench001,00,,NP
+sub,baezj001,"Javier Baez",1,6,5
+play,6,0,pench001,00,,NP
+sub,szczm001,"Matt Szczur",1,7,9
+play,6,0,pench001,00,,NP
+sub,solej001,"Jorge Soler",1,9,7
+play,6,0,pench001,21,....BBCX,63/G
+play,6,0,crawb001,10,BX,S8/L
+play,6,0,panij002,32,BFCB1B1>S,K+SB2
+play,6,0,beltb001,12,BSFN,SB3
+play,6,0,beltb001,12,BSFN.B,WP.3-H(NR)
+play,6,0,beltb001,22,BSFN.B.S,K
+play,6,1,bryak001,22,FSBBX,S8/L
+play,6,1,zobrb001,01,CX,54(1)/FO/G
+play,6,1,russa002,22,C1BB1FFH,HP.1-2
+play,6,1,contw001,11,BFX,S9/F.2-3;1-2
+play,6,1,baezj001,00,X,9/F9LF/SF.3-H;2-3;1-2
+play,6,1,szczm001,32,SBBSFFFBFS,K
+play,7,0,nunee002,00,,NP
+sub,szczm001,"Matt Szczur",1,7,7
+play,7,0,nunee002,00,,NP
+sub,heywj001,"Jason Heyward",1,8,9
+play,7,0,nunee002,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,7,0,nunee002,12,...CBSS,K
+play,7,0,bumgm001,00,,NP
+sub,parkj002,"Jarrett Parker",0,9,11
+play,7,0,parkj002,22,.CBCBX,9/F
+play,7,0,spand001,12,CCBFFFX,43/G
+play,7,1,heywj001,00,,NP
+sub,lopej002,"Javier Lopez",0,9,1
+play,7,1,heywj001,21,.CBBX,43/G
+play,7,1,cahit001,00,,NP
+sub,rossd001,"David Ross",1,9,11
+play,7,1,rossd001,01,.SX,S9/F
+play,7,1,fowld001,00,,NP
+sub,strih001,"Hunter Strickland",0,9,1
+play,7,1,fowld001,20,.BBX,6/P
+play,7,1,bryak001,02,FCX,S8/G+.1-2
+play,7,1,zobrb001,31,BBBCB,W.2-3;1-2
+play,7,1,russa002,02,CFFX,9/L
+play,8,0,pagaa001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,8,0,pagaa001,22,.CBBFFX,8/F
+play,8,0,poseb001,00,X,9/L
+play,8,0,pench001,22,BSBCX,53/G
+play,8,1,contw001,00,,NP
+sub,romos001,"Sergio Romo",0,9,1
+play,8,1,contw001,02,.LSS,K
+play,8,1,baezj001,12,TBSX,31/G/MREV
+com,"replay,8,baezj001,CHN,hallt901,CHI11,,Y,M,SFN,C"
+com,"$when Javier Baez was called safe at 1B, Giants"
+com,"manager Bruce Bochy challenged the ruling; the"
+com,"call was overturned by replay"
+play,8,1,szczm001,00,,NP
+sub,coghc001,"Chris Coghlan",1,7,11
+play,8,1,coghc001,00,,NP
+sub,smitw002,"Will Smith",0,9,1
+play,8,1,coghc001,32,..BCCBBB,W
+play,8,1,heywj001,02,S1S1>FT,K
+play,9,0,crawb001,00,,NP
+sub,bryak001,"Kris Bryant",1,2,7
+play,9,0,crawb001,00,,NP
+sub,woodt004,"Travis Wood",1,7,1
+play,9,0,crawb001,00,,NP
+sub,rizza001,"Anthony Rizzo",1,9,3
+play,9,0,crawb001,22,...CCBFBX,63/G
+play,9,0,panij002,00,X,8/L+
+play,9,0,beltb001,10,BX,8/F
+play,9,1,rizza001,31,BBBCB,W
+play,9,1,fowld001,00,,NP
+sub,garcj002,"Santiago Casilla",0,9,1
+play,9,1,fowld001,11,.BFX,54/BG/DP/SH.1X3(46)
+play,9,1,bryak001,10,BX,6/L-
+data,er,bumgm001,2
+data,er,lopej002,0
+data,er,strih001,0
+data,er,romos001,0
+data,er,smitw002,0
+data,er,garcj002,0
+data,er,arrij001,2
+data,er,cahit001,0
+data,er,grimj002,0
+data,er,woodt004,0
+id,CHN201609040
+version,2
+info,visteam,SFN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/04
+info,number,0
+info,starttime,1:22PM
+info,daynight,day
+info,usedh,false
+info,umphome,cuzzp901
+info,ump1b,hamaa901
+info,ump2b,hallt901
+info,ump3b,belld901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,speaa701
+info,temp,76
+info,winddir,tolf
+info,windspeed,8
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,263
+info,attendance,41293
+info,wp,cahit001
+info,lp,reynm002
+info,save,
+start,spand001,"Denard Span",0,1,8
+start,panij002,"Joe Panik",0,2,4
+start,poseb001,"Buster Posey",0,3,2
+start,pench001,"Hunter Pence",0,4,9
+start,beltb001,"Brandon Belt",0,5,3
+start,parkj002,"Jarrett Parker",0,6,7
+start,nunee002,"Eduardo Nunez",0,7,5
+start,adrie001,"Ehire Adrianza",0,8,6
+start,cuetj001,"Johnny Cueto",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,contw001,"Willson Contreras",1,7,2
+start,coghc001,"Chris Coghlan",1,8,7
+start,lackj001,"John Lackey",1,9,1
+play,1,0,spand001,12,BCFX,43/G
+play,1,0,panij002,01,CX,4/L
+play,1,0,poseb001,32,CBBFFFBX,4/P
+play,1,1,fowld001,10,BX,3/G
+play,1,1,bryak001,01,CX,S7/G+
+play,1,1,rizza001,12,BCFT,K
+play,1,1,zobrb001,32,BCTB*B>F>X,9/F
+play,2,0,pench001,00,X,E9/L+.B-2
+play,2,0,beltb001,32,BFFBBB,W
+play,2,0,parkj002,11,FBX,13/G-.2-3;1-2
+play,2,0,nunee002,20,BBX,63/G.3-H(UR);2-3
+play,2,0,adrie001,22,FBTBT,K
+play,2,1,russa002,11,CBX,D8/L+
+play,2,1,heywj001,11,BCX,63/G
+play,2,1,contw001,12,CFBS,K
+play,2,1,coghc001,00,X,43/G
+play,3,0,cuetj001,22,CBBTS,K
+play,3,0,spand001,12,CFFFFBX,31/G
+play,3,0,panij002,22,BFFFFBS,K
+play,3,1,lackj001,12,BSSC,K
+play,3,1,fowld001,00,X,8/L+
+play,3,1,bryak001,00,X,13/G-
+play,4,0,poseb001,02,FFX,13/G
+play,4,0,pench001,12,BFSS,K
+play,4,0,beltb001,00,X,9/F
+play,4,1,rizza001,01,SX,S7/L
+play,4,1,zobrb001,31,FBBBB,W.1-2
+play,4,1,russa002,00,X,64(1)3/GDP.2-3
+play,4,1,heywj001,12,CCBX,S7/L-.3-H
+play,4,1,contw001,01,1FX,13/G
+play,5,0,parkj002,22,CSBFFBX,31/G
+play,5,0,nunee002,21,BBFX,D8/L+
+play,5,0,adrie001,21,BCB>B,SB3
+play,5,0,adrie001,31,BCB>B.>X,13/BG/SH.3-H
+play,5,0,cuetj001,00,X,4/P
+play,5,1,coghc001,22,CFBBS,K
+play,5,1,lackj001,00,,NP
+sub,szczm001,"Matt Szczur",1,9,11
+play,5,1,szczm001,22,.FBFBFFX,43/G
+play,5,1,fowld001,32,BFBBFFS,K
+play,6,0,spand001,00,,NP
+sub,zastr001,"Rob Zastryzny",1,9,1
+play,6,0,spand001,21,.CBBX,8/F
+play,6,0,panij002,10,BX,S8/G
+play,6,0,poseb001,11,1BSX,54(1)/FO/G
+play,6,0,pench001,32,BFB*BF>S,K23
+play,6,1,bryak001,02,CFH,HP
+play,6,1,rizza001,32,BFF*BFFB1X,64(1)/FO/G
+play,6,1,zobrb001,12,*BCCX,46(1)/FO/G
+play,6,1,russa002,22,BBFFFX,S9/L.1-2
+play,6,1,heywj001,00,X,9/F
+play,7,0,beltb001,00,H,HP
+play,7,0,parkj002,00,,NP
+sub,tomlk001,"Kelby Tomlinson",0,6,11
+play,7,0,tomlk001,00,,NP
+sub,smitj002,"Joe Smith",1,9,1
+play,7,0,tomlk001,00,,NP
+sub,gillc001,"Conor Gillaspie",0,6,11
+play,7,0,gillc001,12,...11BF1FC,K
+play,7,0,nunee002,02,CFX,7/F
+play,7,0,adrie001,00,H,HP.1-2
+play,7,0,cuetj001,02,FLFS,K
+play,7,1,contw001,00,,NP
+sub,willm008,"Mac Williamson",0,6,7
+play,7,1,contw001,21,.CBBX,63/G
+play,7,1,coghc001,11,CBX,3/G+
+play,7,1,smitj002,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,7,1,lastt001,11,.BSX,7/F
+play,8,0,spand001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,spand001,12,.CBFX,63/G
+play,8,0,panij002,01,CX,43/G
+play,8,0,poseb001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,8,0,poseb001,02,.CFX,63/G
+play,8,1,fowld001,00,,NP
+sub,romos001,"Sergio Romo",0,9,1
+play,8,1,fowld001,22,.CBSBS,K
+play,8,1,bryak001,00,X,6/P
+play,8,1,rizza001,00,,NP
+sub,lopej002,"Javier Lopez",0,9,1
+play,8,1,rizza001,12,.CFFBFX,S8/L-
+play,8,1,zobrb001,00,X,64(1)/FO/G+
+play,9,0,pench001,11,SBX,43/G+
+play,9,0,beltb001,32,BMBBFC,K
+play,9,0,willm008,32,CBSBBS,K
+play,9,1,russa002,00,,NP
+sub,herng001,"Gorkys Hernandez",0,6,7
+play,9,1,russa002,00,,NP
+sub,garcj002,"Santiago Casilla",0,9,1
+play,9,1,russa002,22,..FCBFBX,D7/L+
+play,9,1,heywj001,01,CB,WP.2-3
+play,9,1,heywj001,11,CB.X,S8/G.3-H
+play,9,1,contw001,00,1X,16(1)/FO/BG
+play,9,1,coghc001,01,CX,8/F
+play,9,1,edwac001,00,,NP
+sub,solej001,"Jorge Soler",1,9,11
+play,9,1,solej001,31,.BFBBB,W.1-2
+play,9,1,fowld001,32,BCBFB>F>X,7/L
+play,10,0,nunee002,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,10,0,nunee002,00,,NP
+sub,baezj001,"Javier Baez",1,8,4
+play,10,0,nunee002,00,,NP
+sub,chapa001,"Aroldis Chapman",1,9,1
+play,10,0,nunee002,00,...X,8/L+
+play,10,0,adrie001,12,BFFC,K
+play,10,0,garcj002,00,,NP
+sub,pagaa001,"Angel Pagan",0,9,11
+play,10,0,pagaa001,01,.CX,8/F
+play,10,1,bryak001,00,,NP
+sub,kontg001,"George Kontos",0,9,1
+play,10,1,bryak001,12,.CFFBX,9/F
+play,10,1,rizza001,00,,NP
+sub,osicj001,"Josh Osich",0,9,1
+play,10,1,rizza001,21,.BSBX,7/F
+play,10,1,zobrb001,30,BBBB,W
+play,10,1,russa002,00,,NP
+sub,gearc001,"Cory Gearrin",0,9,1
+play,10,1,russa002,22,.SBBS>B,SB2
+play,10,1,russa002,32,.SBBS>B.C,K
+play,11,0,spand001,02,FFS,K
+play,11,0,panij002,32,BSCBBB,W
+play,11,0,poseb001,00,1X,S6/G.1-2
+play,11,0,pench001,12,BSSS,K+PB.2-3;1-2
+play,11,0,beltb001,02,SSS,K
+play,11,1,heywj001,00,,NP
+sub,okers001,"Steven Okert",0,9,1
+play,11,1,heywj001,00,.X,8/L
+play,11,1,contw001,00,X,63/G
+play,11,1,baezj001,21,BCBX,63/G
+play,12,0,herng001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,12,0,herng001,11,.BCX,S6/G
+play,12,0,nunee002,11,*B1T11>B,CS2(24)
+play,12,0,nunee002,31,*B1T11>B.BB,W
+play,12,0,adrie001,00,>B,SB2
+play,12,0,adrie001,32,>B.BBCF>FC,K
+play,12,0,okers001,00,,NP
+sub,crawb001,"Brandon Crawford",0,9,11
+play,12,0,crawb001,02,.FFS,K
+play,12,1,grimj002,00,,NP
+sub,nathj001,"Joe Nathan",0,8,1
+play,12,1,grimj002,00,,NP
+sub,crawb001,"Brandon Crawford",0,9,6
+play,12,1,grimj002,00,,NP
+sub,montm001,"Miguel Montero",1,9,11
+play,12,1,montm001,02,...CFX,7/F
+play,12,1,fowld001,11,CBX,7/F
+play,12,1,bryak001,12,SBFFS,K
+play,13,0,spand001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,13,0,spand001,32,.SBMBFBX,31/G
+play,13,0,panij002,00,X,43/G
+play,13,0,poseb001,11,CBX,43/G+
+play,13,1,rizza001,00,,NP
+sub,reynm002,"Matt Reynolds",0,8,1
+play,13,1,rizza001,22,.BCFFBX,S7/L
+play,13,1,zobrb001,10,BX,3/G-.1-2
+play,13,1,russa002,30,IIII,IW
+play,13,1,heywj001,12,CBFX,S8/L.2-H;1-2
+data,er,cuetj001,1
+data,er,romos001,0
+data,er,lopej002,0
+data,er,garcj002,1
+data,er,kontg001,0
+data,er,osicj001,0
+data,er,gearc001,0
+data,er,okers001,0
+data,er,nathj001,0
+data,er,reynm002,1
+data,er,lackj001,1
+data,er,zastr001,0
+data,er,smitj002,0
+data,er,woodt004,0
+data,er,edwac001,0
+data,er,chapa001,0
+data,er,grimj002,0
+data,er,cahit001,0
+id,CHN201609150
+version,2
+info,visteam,MIL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/15
+info,number,0
+info,starttime,7:05PM
+info,daynight,night
+info,usedh,false
+info,umphome,littw901
+info,ump1b,barkl901
+info,ump2b,herna901
+info,ump3b,barrt901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,70
+info,winddir,tolf
+info,windspeed,9
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,190
+info,attendance,41362
+info,wp,nelsj004
+info,lp,grimj002
+info,save,thort001
+start,villj001,"Jonathan Villar",0,1,4
+start,broxk001,"Keon Broxton",0,2,8
+start,braur002,"Ryan Braun",0,3,7
+start,cartc002,"Chris Carter",0,4,3
+start,pereh001,"Hernan Perez",0,5,5
+start,santd002,"Domingo Santana",0,6,9
+start,arcio002,"Orlando Arcia",0,7,6
+start,maldm001,"Martin Maldonado",0,8,2
+start,nelsj004,"Jimmy Nelson",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,solej001,"Jorge Soler",1,6,7
+start,heywj001,"Jason Heyward",1,7,9
+start,montm001,"Miguel Montero",1,8,2
+start,montm002,"Mike Montgomery",1,9,1
+play,1,0,villj001,00,X,S7/G+
+play,1,0,broxk001,22,1BBT11SX,8/L+
+play,1,0,braur002,00,X,64(1)3/GDP
+play,1,1,fowld001,32,BCBBCC,K
+play,1,1,bryak001,00,X,63/G-
+play,1,1,rizza001,00,X,S9/L
+play,1,1,zobrb001,02,CCFX,46(1)/FO/G
+play,2,0,cartc002,30,BBBB,W
+play,2,0,pereh001,12,CBSC,K
+play,2,0,santd002,02,FSS,K
+play,2,0,arcio002,00,X,8/F-
+play,2,1,russa002,10,BX,S5/P
+play,2,1,solej001,10,BX,HR/7/L.1-H
+play,2,1,heywj001,12,BCSX,63/G
+play,2,1,montm001,22,CBSFBX,S8/L
+play,2,1,montm002,02,SMFS,K
+play,2,1,fowld001,02,CSS,K
+play,3,0,maldm001,22,CCBBS,K
+play,3,0,nelsj004,02,FCS,K
+play,3,0,villj001,22,FFBBX,63/G
+play,3,1,bryak001,12,FCBX,3/L-
+play,3,1,rizza001,31,FBBBB,W
+play,3,1,zobrb001,30,BBBB,W.1-2
+play,3,1,russa002,22,BFBFFFX,4(1)3/GDP
+play,4,0,broxk001,32,SBBSBFX,HR/8/F
+play,4,0,braur002,22,CBBSFFX,63/G+
+play,4,0,cartc002,02,SSC,K
+play,4,0,pereh001,22,BSFFBFFX,E6/TH/G
+play,4,0,santd002,02,C1SF>X,D9/L.1-3
+play,4,0,arcio002,20,*B*BX,D7/L.3-H(UR);2-H(UR)
+play,4,0,maldm001,01,CX,53/G
+play,4,1,solej001,32,BBSBSS,K
+play,4,1,heywj001,11,CBX,D7/L
+play,4,1,montm001,12,CTBX,8/F.2-3
+play,4,1,montm002,10,BX,S8/G.3-H
+play,4,1,fowld001,21,BSBX,S98/G.1-2
+play,4,1,bryak001,02,SSS,K
+play,5,0,nelsj004,22,BCBSC,K
+play,5,0,villj001,12,BTSS,K
+play,5,0,broxk001,22,BCSBX,63/G+
+play,5,1,rizza001,12,CBFS,K
+play,5,1,zobrb001,12,CFFBFX,43/G
+play,5,1,russa002,21,BSBX,63/G
+play,6,0,braur002,00,X,53/G
+play,6,0,cartc002,00,X,53/G
+play,6,0,pereh001,11,CBX,53/G
+play,6,1,solej001,00,X,8/F
+play,6,1,heywj001,10,BX,9/F
+play,6,1,montm001,01,SX,S8/L+
+play,6,1,montm002,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,6,1,lastt001,22,.CSB*BFFFS,K
+play,7,0,santd002,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,7,0,santd002,10,.BX,D8/L+
+play,7,0,arcio002,22,SBFBC,K
+play,7,0,maldm001,32,*BCBS*B*B,W
+play,7,0,nelsj004,00,,NP
+sub,genns001,"Scooter Gennett",0,9,11
+play,7,0,genns001,02,.CFX,D7/F.2-H;1-H
+play,7,0,villj001,22,FBBSC,K
+play,7,0,broxk001,00,,NP
+sub,smitj002,"Joe Smith",1,9,1
+play,7,0,broxk001,32,.BCBSBFS,K
+play,7,1,fowld001,00,,NP
+sub,torrc001,"Carlos Torres",0,9,1
+play,7,1,fowld001,01,.SX,53/G
+play,7,1,bryak001,12,CBFX,S8/G
+play,7,1,rizza001,00,1X,43/G.1-2
+play,7,1,zobrb001,11,CB+2,PO2(26)
+play,8,0,braur002,00,X,S9/G
+play,8,0,cartc002,02,FC1,PO1(13)/MREV
+com,"replay,8,cartc002,MIL,barrt901,CHI11,,Y,M,CHN,A"
+com,"$when Ryan Braun was called safe at 1B, Cubs"
+com,"manager Joe Maddon challenged the ruling; the"
+com,"call was overturned by replay"
+play,8,0,cartc002,32,FC1.BBBX,8/F
+play,8,0,pereh001,12,CBFX,E6/TH/G
+play,8,0,santd002,01,1C1X,4/L+
+play,8,1,zobrb001,32,BBBCFB,W
+play,8,1,russa002,22,F1BS11B1FS,K
+play,8,1,solej001,22,BBCFC,K
+play,8,1,heywj001,00,,NP
+sub,pereh001,"Hernan Perez",0,5,9
+play,8,1,heywj001,00,,NP
+sub,thort001,"Tyler Thornburg",0,6,1
+play,8,1,heywj001,00,,NP
+sub,rivey001,"Yadiel Rivera",0,9,5
+play,8,1,heywj001,01,...FX,D9/L.1-H
+play,8,1,montm001,10,BB,PB.2-3
+play,8,1,montm001,31,BB.CBB,W
+play,8,1,smitj002,00,,NP
+sub,szczm001,"Matt Szczur",1,8,12
+play,8,1,smitj002,00,,NP
+sub,contw001,"Willson Contreras",1,9,11
+play,8,1,contw001,22,..BBCCFC,K
+play,9,0,arcio002,00,,NP
+sub,patts002,"Spencer Patton",1,8,1
+play,9,0,arcio002,00,,NP
+sub,contw001,"Willson Contreras",1,9,2
+play,9,0,arcio002,00,..X,8/L
+play,9,0,maldm001,22,BBCFT,K
+play,9,0,rivey001,21,BSBX,53/G
+play,9,1,fowld001,22,BFFFBC,K
+play,9,1,bryak001,32,BBFBCX,63/G
+play,9,1,rizza001,32,BCBBSB,W
+play,9,1,zobrb001,00,,NP
+sub,baezj001,"Javier Baez",1,3,12
+play,9,1,zobrb001,01,.CX,6(1)/FO/G
+data,er,nelsj004,3
+data,er,torrc001,1
+data,er,thort001,0
+data,er,montm002,1
+data,er,grimj002,2
+data,er,smitj002,0
+data,er,patts002,0
+id,CHN201609160
+version,2
+info,visteam,MIL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/16
+info,number,0
+info,starttime,1:21PM
+info,daynight,day
+info,usedh,false
+info,umphome,barkl901
+info,ump1b,herna901
+info,ump2b,barrt901
+info,ump3b,littw901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,79
+info,winddir,tocf
+info,windspeed,8
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,193
+info,attendance,40823
+info,wp,chapa001
+info,lp,boyeb001
+info,save,
+start,broxk001,"Keon Broxton",0,1,8
+start,genns001,"Scooter Gennett",0,2,4
+start,braur002,"Ryan Braun",0,3,7
+start,cartc002,"Chris Carter",0,4,3
+start,pereh001,"Hernan Perez",0,5,5
+start,santd002,"Domingo Santana",0,6,9
+start,arcio002,"Orlando Arcia",0,7,6
+start,susaa001,"Andrew Susac",0,8,2
+start,andec001,"Chase Anderson",0,9,1
+start,szczm001,"Matt Szczur",1,1,9
+start,baezj001,"Javier Baez",1,2,6
+start,solej001,"Jorge Soler",1,3,7
+start,contw001,"Willson Contreras",1,4,2
+start,coghc001,"Chris Coghlan",1,5,3
+start,almoa002,"Albert Almora",1,6,8
+start,lastt001,"Tommy La Stella",1,7,5
+start,kawam001,"Munenori Kawasaki",1,8,4
+start,lackj001,"John Lackey",1,9,1
+play,1,0,broxk001,00,X,S7/L
+play,1,0,genns001,00,X,6/P
+play,1,0,braur002,00,>B,SB2.1-3(E2/TH)
+play,1,0,braur002,22,>B.SFBS,K
+play,1,0,cartc002,22,SBS*BC,K
+play,1,1,szczm001,30,BBBB,W
+play,1,1,baezj001,02,SFS,K
+play,1,1,solej001,01,TX,46(1)3/GDP
+play,2,0,pereh001,02,CFX,9/F
+play,2,0,santd002,12,BFFX,8/L
+play,2,0,arcio002,00,X,HR/78/F
+play,2,0,susaa001,31,BCBBB,W
+play,2,0,andec001,22,BFC*BS,K
+play,2,1,contw001,12,CBFFC,K
+play,2,1,coghc001,22,BSBFFX,S9/L
+play,2,1,almoa002,01,CX,54(1)3/GDP
+play,3,0,broxk001,32,CBSBBB,W
+play,3,0,genns001,22,1C11BB1S>B,CS2(26)
+play,3,0,genns001,32,1C11BB1S>B.FX,7/F
+play,3,0,braur002,10,BX,HR/8/F
+play,3,0,cartc002,12,BCCFS,K
+play,3,1,lastt001,01,CX,8/L
+play,3,1,kawam001,00,,NP
+sub,nieuk001,"Kirk Nieuwenhuis",0,1,8
+play,3,1,kawam001,01,.SX,13/BG
+play,3,1,lackj001,01,FX,13/G-
+play,4,0,pereh001,00,,NP
+sub,montm001,"Miguel Montero",1,3,2
+play,4,0,pereh001,00,,NP
+sub,contw001,"Willson Contreras",1,4,7
+play,4,0,pereh001,00,..X,S14/G
+play,4,0,santd002,00,X,8/L
+play,4,0,arcio002,00,X,46(1)3/GDP
+play,4,1,szczm001,32,BBCBFX,7/F
+play,4,1,baezj001,00,X,5/L+
+play,4,1,montm001,30,BBBB,W
+play,4,1,contw001,01,CX,8/L
+play,5,0,susaa001,22,BCFFBX,S7/L+
+play,5,0,andec001,12,BFFX,9/L
+play,5,0,nieuk001,12,FBFFS,K
+play,5,0,genns001,22,BF*BSX,S7/L.1-2
+play,5,0,braur002,21,BBCX,8/F
+play,5,1,coghc001,01,CX,S7/L
+play,5,1,almoa002,32,BBSFBX,HR/8/L.1-H
+play,5,1,lastt001,32,BFBSBB,W
+play,5,1,kawam001,22,FFBBX,S4/G-.1-2
+play,5,1,lackj001,00,X,46(1)3/GDP/MREV.2-3
+com,"replay,5,lackj001,CHN,barrt901,CHI11,,Y,M,MIL,C"
+com,"$when John Lackey was called safe at 1B, Brewers"
+com,"manager Craig Counsell challenged the ruling; the"
+com,"call was overturned by replay"
+play,5,1,szczm001,32,BSBBFX,63/G
+play,6,0,cartc002,12,CFBS,K
+play,6,0,pereh001,02,CFX,8/F
+play,6,0,santd002,01,CX,D9/L+
+play,6,0,arcio002,22,FS*BBS,K
+play,6,1,baezj001,32,BBBCSS,K
+play,6,1,montm001,22,FBBSX,7/F
+play,6,1,contw001,00,X,D7/L+
+play,6,1,coghc001,22,BCBFFX,4/P
+play,7,0,susaa001,00,X,S8/L
+play,7,0,andec001,00,,NP
+sub,pinam001,"Manny Pina",0,9,11
+play,7,0,pinam001,32,.BC.BSBX,43/G-.1-2
+play,7,0,nieuk001,10,BX,63/G.2-3
+play,7,0,genns001,10,BX,HR/89/F.3-H
+play,7,0,braur002,02,SSS,K
+play,7,1,almoa002,00,,NP
+sub,rivey001,"Yadiel Rivera",0,1,5
+play,7,1,almoa002,00,,NP
+sub,pereh001,"Hernan Perez",0,5,9
+play,7,1,almoa002,00,,NP
+sub,santd002,"Domingo Santana",0,6,8
+play,7,1,almoa002,00,,NP
+sub,barnj002,"Jacob Barnes",0,9,1
+com,"Brewers center fielder Keon Broxton left the game due to an injured wrist"
+play,7,1,almoa002,00,....X,S9/L
+play,7,1,lastt001,00,,NP
+sub,suteb001,"Brent Suter",0,9,1
+play,7,1,lastt001,01,.C1X,S9/G/MREV.1X2(96)
+com,"replay,7,lastt001,CHN,barrt901,CHI11,,N,M,CHN,A"
+com,"$when Albert Almora was called out at 2B after rounding"
+com,"the bag too far, Cubs manager Joe Maddon challenged the"
+com,"ruling; the call was upheld by replay"
+play,7,1,kawam001,32,BB1BCFB,W.1-2
+play,7,1,lackj001,00,,NP
+sub,rossd001,"David Ross",1,9,11
+play,7,1,rossd001,00,,NP
+sub,marij001,"Jhan Marinez",0,9,1
+play,7,1,rossd001,00,..X,54(1)3/GDP
+play,8,0,cartc002,00,,NP
+sub,penaf002,"Felix Pena",1,9,1
+play,8,0,cartc002,00,.X,S7/L
+play,8,0,pereh001,02,CFX,8/F
+play,8,0,santd002,00,X,8/F
+play,8,0,arcio002,32,CBBSB>T,K
+play,8,1,szczm001,00,,NP
+sub,knebc001,"Corey Knebel",0,9,1
+play,8,1,szczm001,12,.CBCX,9/L
+play,8,1,baezj001,22,CBSBX,3/P
+play,8,1,montm001,22,CBSBFS,K
+play,9,0,susaa001,00,X,3/P
+play,9,0,knebc001,00,,NP
+sub,villj001,"Jonathan Villar",0,9,11
+play,9,0,villj001,22,.BBCSS,K
+play,9,0,rivey001,22,FCFBBX,2/FL
+play,9,1,contw001,00,,NP
+sub,torrc001,"Carlos Torres",0,9,1
+play,9,1,contw001,02,.FFFX,D9/L
+play,9,1,coghc001,00,X,S8/L+.2-H
+play,9,1,almoa002,10,BX,7/L+
+play,9,1,lastt001,11,C*B1>X,E3/G+.1-2
+play,9,1,kawam001,01,CH,HP.2-3;1-2
+play,9,1,penaf002,00,,NP
+sub,russa002,"Addison Russell",1,9,11
+play,9,1,russa002,22,.FSFB*BX,S4/G-.3-H(UR);2-3;1-2
+play,9,1,szczm001,32,BFBBFX,8/L
+play,9,1,baezj001,32,BFSBB>X,13/G-
+play,10,0,genns001,00,,NP
+sub,chapa001,"Aroldis Chapman",1,9,1
+play,10,0,genns001,00,,NP
+sub,elmoj001,"Jake Elmore",0,2,11
+play,10,0,elmoj001,22,..BBCCS,K
+play,10,0,braur002,02,FCS,K
+play,10,0,cartc002,02,CSS,K
+play,10,1,montm001,00,,NP
+sub,elmoj001,"Jake Elmore",0,2,4
+play,10,1,montm001,00,,NP
+sub,boyeb001,"Blaine Boyer",0,9,1
+play,10,1,montm001,11,..FBX,HR/7/F
+data,er,andec001,2
+data,er,barnj002,0
+data,er,suteb001,0
+data,er,marij001,0
+data,er,knebc001,0
+data,er,torrc001,1
+data,er,boyeb001,1
+data,er,lackj001,4
+data,er,penaf002,0
+data,er,chapa001,0
+id,CHN201609170
+version,2
+info,visteam,MIL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/17
+info,number,0
+info,starttime,3:06PM
+info,daynight,day
+info,usedh,false
+info,umphome,herna901
+info,ump1b,barrt901
+info,ump2b,littw901
+info,ump3b,barkl901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,seipb701
+info,temp,81
+info,winddir,tocf
+info,windspeed,12
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,182
+info,attendance,40956
+info,wp,daviz001
+info,lp,arrij001
+info,save,
+start,villj001,"Jonathan Villar",0,1,5
+start,genns001,"Scooter Gennett",0,2,4
+start,braur002,"Ryan Braun",0,3,7
+start,cartc002,"Chris Carter",0,4,3
+start,pereh001,"Hernan Perez",0,5,9
+start,santd002,"Domingo Santana",0,6,8
+start,arcio002,"Orlando Arcia",0,7,6
+start,maldm001,"Martin Maldonado",0,8,2
+start,daviz001,"Zach Davies",0,9,1
+start,lastt001,"Tommy La Stella",1,1,5
+start,bryak001,"Kris Bryant",1,2,3
+start,coghc001,"Chris Coghlan",1,3,7
+start,contw001,"Willson Contreras",1,4,2
+start,almoa002,"Albert Almora",1,5,8
+start,baezj001,"Javier Baez",1,6,6
+start,szczm001,"Matt Szczur",1,7,9
+start,kawam001,"Munenori Kawasaki",1,8,4
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,villj001,31,FBBBB,W
+play,1,0,genns001,10,B11>C,SB2
+play,1,0,genns001,12,B11>C.TS,K
+play,1,0,braur002,01,F>X,4/P
+play,1,0,cartc002,21,FB+2BX,13/G-
+play,1,1,lastt001,10,BX,S8/L+
+play,1,1,bryak001,10,BX,T8/L+.1-H
+play,1,1,coghc001,00,X,HR/9/F.3-H
+play,1,1,contw001,22,CBSBS,K
+play,1,1,almoa002,32,BBCTFBS,K
+play,1,1,baezj001,22,BFBST,K
+play,2,0,pereh001,12,CFBX,S9/L-
+play,2,0,santd002,11,F1BX,8/L
+play,2,0,arcio002,11,1F1BX,14(1)3/GDP
+play,2,1,szczm001,02,FFX,S7/G
+play,2,1,kawam001,01,C>B,CS2(26)
+play,2,1,kawam001,11,C>B.X,7/F
+play,2,1,arrij001,31,BBBFX,63/G+
+play,3,0,maldm001,11,CBX,4/P
+play,3,0,daviz001,22,BFBFT,K
+play,3,0,villj001,31,CBBBX,63/G
+play,3,1,lastt001,32,CBFBBFFFX,3/G
+play,3,1,bryak001,32,BCBBFC,K
+play,3,1,coghc001,12,SSBX,13/G-
+play,4,0,genns001,02,CSX,E5/G
+play,4,0,braur002,00,1B,WP.1-2
+play,4,0,braur002,20,1B.BX,S7/L+.2-H(UR)
+play,4,0,cartc002,31,*BBBFB,W.1-2
+play,4,0,pereh001,00,X,4/P/IF
+play,4,0,santd002,02,CFX,14(1)3/GDP
+play,4,1,contw001,02,FCX,S7/L
+play,4,1,almoa002,00,1X,S8/L.1-2
+play,4,1,baezj001,30,*B*BBB,W.2-3;1-2
+play,4,1,szczm001,12,BCTFFS,K
+play,4,1,kawam001,22,FSB*BX,64(1)3/GDP
+play,5,0,arcio002,01,CX,7/F
+play,5,0,maldm001,22,CBFBC,K
+play,5,0,daviz001,02,CFS,K
+play,5,1,arrij001,11,CBX,53/G
+play,5,1,lastt001,12,CCBX,S8/L-
+play,5,1,bryak001,01,SH,HP.1-2
+play,5,1,coghc001,10,BX,64(1)/FO/G.2-3
+play,5,1,contw001,12,SSBX,63/G
+play,6,0,villj001,32,BBBCCB,W
+play,6,0,genns001,11,S1B>B,SB2
+play,6,0,genns001,31,S1B>B.BX,DGR/7/F.2-H
+play,6,0,braur002,32,CBF*B*BX,HR/78/F.2-H
+play,6,0,cartc002,21,BBSX,5/P
+play,6,0,pereh001,12,FBSX,63/G
+play,6,0,santd002,32,BSSBBF*B,W
+play,6,0,arcio002,32,CBFB>FB>S,K
+play,6,1,almoa002,00,,NP
+sub,marij001,"Jhan Marinez",0,9,1
+play,6,1,almoa002,00,.X,7/L+
+play,6,1,baezj001,01,CX,D7/L+
+play,6,1,szczm001,22,BFFFBS,K
+play,6,1,kawam001,01,CB,PB.2-3
+play,6,1,kawam001,32,CB.BBSX,9/L
+play,7,0,maldm001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,7,0,maldm001,11,.BCX,5/L
+play,7,0,marij001,00,,NP
+sub,reedm001,"Michael Reed",0,9,11
+play,7,0,reedm001,22,.SCBBT,K
+play,7,0,villj001,00,X,6/P
+play,7,1,cahit001,00,,NP
+sub,knebc001,"Corey Knebel",0,9,1
+play,7,1,cahit001,00,,NP
+sub,russa002,"Addison Russell",1,9,11
+play,7,1,russa002,12,..BSCX,53/G
+play,7,1,lastt001,32,CBBFBX,13/G
+play,7,1,bryak001,32,BCBBCB,W
+play,7,1,coghc001,01,1CB,WP.1-2
+play,7,1,coghc001,32,1CB.C*B*BC,K
+play,8,0,genns001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,8,0,genns001,10,.BX,D9/L
+play,8,0,braur002,22,SCB*BX,HR/78/L.2-H
+play,8,0,cartc002,22,FBCBS,K
+play,8,0,pereh001,12,BTSS,K
+play,8,0,santd002,01,CX,HR/7/F
+play,8,0,arcio002,12,FBSS,K
+play,8,1,contw001,00,,NP
+sub,barnj002,"Jacob Barnes",0,9,1
+play,8,1,contw001,21,.BBFX,9/L
+play,8,1,almoa002,22,BCSBT,K
+play,8,1,baezj001,11,BTX,7/L
+play,9,0,maldm001,00,,NP
+sub,patts002,"Spencer Patton",1,9,1
+play,9,0,maldm001,20,.BBX,9/F
+play,9,0,barnj002,00,,NP
+sub,pinam001,"Manny Pina",0,9,11
+play,9,0,pinam001,32,.SBCBBB,W
+play,9,0,villj001,31,BBBCB,W.1-2
+play,9,0,genns001,01,FH,HP.2-3;1-2
+play,9,0,braur002,02,FSFS,K
+play,9,0,cartc002,01,SX,HR/78/F.3-H;2-H;1-H
+play,9,0,pereh001,12,SFBS,K
+play,9,1,szczm001,00,,NP
+sub,scahr001,"Rob Scahill",0,9,1
+play,9,1,szczm001,11,.SBX,9/F
+play,9,1,kawam001,12,BFFS,K
+play,9,1,patts002,00,,NP
+sub,montm001,"Miguel Montero",1,9,11
+play,9,1,montm001,12,.CCBX,13/G-
+data,er,daviz001,3
+data,er,marij001,0
+data,er,knebc001,0
+data,er,barnj002,0
+data,er,scahr001,0
+data,er,arrij001,3
+data,er,cahit001,0
+data,er,edwac001,3
+data,er,patts002,4
+id,CHN201609180
+version,2
+info,visteam,MIL
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/18
+info,number,0
+info,starttime,1:20PM
+info,daynight,day
+info,usedh,false
+info,umphome,barrt901
+info,ump1b,littw901
+info,ump2b,barkl901
+info,ump3b,herna901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,speaa701
+info,temp,69
+info,winddir,tolf
+info,windspeed,11
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,cloudy
+info,timeofgame,157
+info,attendance,41286
+info,wp,peraw001
+info,lp,hendk001
+info,save,thort001
+start,villj001,"Jonathan Villar",0,1,5
+start,genns001,"Scooter Gennett",0,2,4
+start,cartc002,"Chris Carter",0,3,3
+start,pereh001,"Hernan Perez",0,4,9
+start,santd002,"Domingo Santana",0,5,8
+start,arcio002,"Orlando Arcia",0,6,6
+start,maldm001,"Martin Maldonado",0,7,2
+start,reedm001,"Michael Reed",0,8,7
+start,peraw001,"Wily Peralta",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,7
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,montm001,"Miguel Montero",1,7,2
+start,baezj001,"Javier Baez",1,8,4
+start,hendk001,"Kyle Hendricks",1,9,1
+play,1,0,villj001,02,CSC,K
+play,1,0,genns001,22,BCSFBS,K
+play,1,0,cartc002,22,CBFBS,K
+play,1,1,fowld001,10,BX,3/G
+play,1,1,bryak001,00,X,43/G
+play,1,1,rizza001,11,CBX,3/G
+play,2,0,pereh001,02,CCFX,S7/L-
+play,2,0,santd002,22,CBBS1C,K
+play,2,0,arcio002,00,111>C,SB2
+play,2,0,arcio002,02,111>C.CX,63/G.2-3
+play,2,0,maldm001,31,BBBCX,S8/G.3-H
+play,2,0,reedm001,11,BCX,S9/L.1-2
+play,2,0,peraw001,00,X,S8/G+.2-H;1-2
+play,2,0,villj001,22,FBBSFX,64(1)/FO/G
+play,2,1,zobrb001,22,CCFBBX,3/G
+play,2,1,russa002,32,BSBBSX,S8/G
+play,2,1,heywj001,00,X,S9/L.1-2
+play,2,1,montm001,11,CBX,7/L+
+play,2,1,baezj001,32,S*BFB*B>F>S,K
+play,3,0,genns001,11,CBX,43/G
+play,3,0,cartc002,02,FCS,K
+play,3,0,pereh001,11,BCX,43/G
+play,3,1,hendk001,20,BBX,S9/L
+play,3,1,fowld001,32,BFBFBFS,K
+play,3,1,bryak001,11,CBX,S8/G+.1-2
+play,3,1,rizza001,30,BBBB,W.2-3;1-2
+play,3,1,zobrb001,22,BCBCFS,K
+play,3,1,russa002,11,SBX,3/P
+play,4,0,santd002,30,BBBX,8/F
+play,4,0,arcio002,00,X,D87/L+
+play,4,0,maldm001,21,C*BB>C,SB3
+play,4,0,maldm001,22,C*BB>C.FX,9/L
+play,4,0,reedm001,32,FBBBCC,K
+play,4,1,heywj001,02,CCFC,K
+play,4,1,montm001,00,X,3/G
+play,4,1,baezj001,01,SX,S6/G-
+play,4,1,hendk001,20,BBX,S9/L.1-2
+play,4,1,fowld001,32,BSF*BB>C,K
+play,5,0,peraw001,00,X,9/F-
+play,5,0,villj001,22,CBCFBFS,K
+play,5,0,genns001,11,BLX,D7/F
+play,5,0,cartc002,32,S*BBBFS,K
+play,5,1,bryak001,11,FBX,63/G
+play,5,1,rizza001,21,CBBX,D7/L
+play,5,1,zobrb001,01,CX,9/F.2-3
+play,5,1,russa002,11,BSX,7/F
+play,6,0,pereh001,32,LBBSBX,63/G
+play,6,0,santd002,00,X,8/F
+play,6,0,arcio002,32,BBBCCS,K
+play,6,1,heywj001,20,BBX,S8/G
+play,6,1,montm001,10,BX,6/P
+play,6,1,baezj001,00,X,64(1)/FO/G
+play,6,1,hendk001,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,6,1,lastt001,11,.*BCX,D7/L+.1-H
+play,6,1,fowld001,00,X,43/G
+play,7,0,maldm001,00,,NP
+sub,smitj002,"Joe Smith",1,9,1
+play,7,0,maldm001,12,.CSBC,K
+play,7,0,reedm001,00,X,43/G
+play,7,0,peraw001,00,,NP
+sub,elmoj001,"Jake Elmore",0,9,11
+play,7,0,elmoj001,01,.CX,13/G
+play,7,1,bryak001,00,,NP
+sub,torrc001,"Carlos Torres",0,9,1
+play,7,1,bryak001,22,.BFSBC,K
+play,7,1,rizza001,00,X,9/L
+play,7,1,zobrb001,12,CBFX,1/G-
+play,8,0,villj001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,8,0,villj001,02,.SSFFX,63/G+
+play,8,0,genns001,02,MCS,K
+play,8,0,cartc002,00,,NP
+sub,penaf002,"Felix Pena",1,9,1
+play,8,0,cartc002,32,.SBCBBX,HR/7/F
+play,8,0,pereh001,01,CX,9/L
+play,8,1,russa002,01,FX,63/G
+play,8,1,heywj001,11,CBX,7/F7LF
+play,8,1,montm001,32,FBBBTS,K
+play,9,0,santd002,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,9,0,santd002,02,.CCS,K
+play,9,0,arcio002,00,X,13/G
+play,9,0,maldm001,31,BBCBB,W
+play,9,0,reedm001,00,X,54(1)/FO/G
+play,9,1,baezj001,00,,NP
+sub,villj001,"Jonathan Villar",0,1,4
+play,9,1,baezj001,00,,NP
+sub,rivey001,"Yadiel Rivera",0,2,5
+play,9,1,baezj001,00,,NP
+sub,thort001,"Tyler Thornburg",0,9,1
+play,9,1,baezj001,21,...BFBH,HP/MREV
+com,"replay,9,baezj001,CHN,barrt901,CHI11,,N,M,MIL,I"
+com,"$when Javier Baez was ruled to have been hit by a"
+com,"pitch, Brewers manager Craig Counsell challenged"
+com,"the ruling; the call was upheld by replay"
+play,9,1,cahit001,00,,NP
+sub,coghc001,"Chris Coghlan",1,9,11
+play,9,1,coghc001,12,.BFCX,3/G.1-2
+play,9,1,fowld001,31,BB*BCB,W
+play,9,1,bryak001,12,C*BSS,K
+play,9,1,rizza001,02,CCS,K
+data,er,peraw001,1
+data,er,torrc001,0
+data,er,thort001,0
+data,er,hendk001,2
+data,er,smitj002,0
+data,er,woodt004,0
+data,er,penaf002,1
+data,er,cahit001,0
+id,CHN201609190
+version,2
+info,visteam,CIN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/19
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,estam901
+info,ump1b,hicke901
+info,ump2b,demud901
+info,ump3b,fleta901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,84
+info,winddir,tocf
+info,windspeed,7
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,162
+info,attendance,39251
+info,wp,hammj002
+info,lp,woodb004
+info,save,chapa001
+start,peraj003,"Jose Peraza",0,1,6
+start,iribh001,"Hernan Iribarren",0,2,8
+start,vottj001,"Joey Votto",0,3,3
+start,duvaa001,"Adam Duvall",0,4,7
+start,philb001,"Brandon Phillips",0,5,4
+start,sches001,"Scott Schebler",0,6,9
+start,suare001,"Eugenio Suarez",0,7,5
+start,barnt001,"Tucker Barnhart",0,8,2
+start,adlet001,"Tim Adleman",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,contw001,"Willson Contreras",1,7,2
+start,coghc001,"Chris Coghlan",1,8,7
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,peraj003,10,BX,7/F
+play,1,0,iribh001,32,BCCBBX,63/G
+play,1,0,vottj001,31,BBCBB,W
+play,1,0,duvaa001,12,BFSS,K
+play,1,1,fowld001,01,CX,31/G
+play,1,1,bryak001,02,CSS,K
+play,1,1,rizza001,11,FBX,13/G-
+play,2,0,philb001,11,BSX,HR/78/L
+play,2,0,sches001,01,LX,53/G+
+play,2,0,suare001,21,CBBX,63/G
+play,2,0,barnt001,00,X,3/G
+play,2,1,zobrb001,12,CFBX,S39/L
+play,2,1,russa002,01,CX,5/P
+play,2,1,heywj001,12,BCST,K
+play,2,1,contw001,10,BX,53/G
+play,3,0,adlet001,02,CCX,8/F
+play,3,0,peraj003,01,CX,S8/L
+play,3,0,iribh001,10,1B1>S,CS2(26)
+play,3,0,iribh001,12,1B1>S.CS,K
+play,3,1,coghc001,22,CFFBBFFX,8/F
+play,3,1,hammj002,02,SSS,K
+play,3,1,fowld001,32,BCBBFFFC,K
+play,4,0,vottj001,20,BBX,43/G
+play,4,0,duvaa001,01,FX,6/L
+play,4,0,philb001,22,CBCBX,E6/TH/G-.B-2
+play,4,0,sches001,32,BBSFB+2S,K
+play,4,1,bryak001,02,FCFC,K
+play,4,1,rizza001,21,FBBX,S9/L+
+play,4,1,zobrb001,21,CBBX,4/L+
+play,4,1,russa002,32,1BB*BFT>X,64(1)/FO/G+
+play,5,0,suare001,32,BBSFBX,63/G
+play,5,0,barnt001,12,CSBFFC,K
+play,5,0,adlet001,12,CSBS,K
+play,5,1,heywj001,01,FX,43/G
+play,5,1,contw001,10,BH,HP
+play,5,1,coghc001,01,CX,6/L
+play,5,1,hammj002,12,F1FB1X,7/F
+play,6,0,peraj003,01,CX,63/G
+play,6,0,iribh001,12,FBCX,T9/L
+play,6,0,vottj001,10,BX,S8/F-.3-H
+play,6,0,duvaa001,31,BSBBX,7/L+
+play,6,0,philb001,22,BCBFFX,7/F
+play,6,1,fowld001,22,CBBFX,7/F
+play,6,1,bryak001,00,X,7/F
+play,6,1,rizza001,11,FBX,D7/F
+play,6,1,zobrb001,11,CBX,9/F
+play,7,0,sches001,00,X,53/G
+play,7,0,suare001,12,BCCS,K
+play,7,0,barnt001,32,CFBBFFFBX,8/F
+play,7,1,russa002,10,BX,HR/7/F
+play,7,1,heywj001,11,BCX,8/L
+play,7,1,contw001,22,CFBBX,HR/7/F
+play,7,1,coghc001,00,,NP
+sub,woodb004,"Blake Wood",0,7,1
+play,7,1,coghc001,00,,NP
+sub,dejei002,"Ivan De Jesus",0,9,5
+play,7,1,coghc001,10,..BX,D9/L+
+play,7,1,hammj002,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,7,1,lastt001,10,.BX,6/P
+play,7,1,fowld001,11,FBX,S8/L.2-H
+play,7,1,bryak001,01,11SX,8/F+
+play,8,0,dejei002,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,8,0,dejei002,00,,NP
+sub,baezj001,"Javier Baez",1,8,4
+play,8,0,dejei002,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,8,0,dejei002,01,...CX,43/G
+play,8,0,peraj003,12,CCBFX,S8/F-
+play,8,0,iribh001,02,C1FT,K
+play,8,0,vottj001,12,C1BS1X,S7/L.1-2
+play,8,0,duvaa001,10,BX,5/P5F
+play,8,1,rizza001,02,CFFS,K
+play,8,1,zobrb001,32,CFBBFBX,8/F
+play,8,1,russa002,20,BBX,D7/L
+play,8,1,heywj001,31,BBBCX,HR/78/F.2-H
+play,8,1,contw001,02,CSX,9/F
+play,9,0,philb001,00,,NP
+sub,chapa001,"Aroldis Chapman",1,9,1
+play,9,0,philb001,22,.BFSFFBFX,13/G-
+play,9,0,sches001,20,BBN,OA/MREV
+com,"replay,9,sches001,CIN,demud901,CHI11,,N,M,CIN,I"
+com,"$when Scott Schebler was ruled not to have been hit"
+com,"by a pitch, Reds manager Bryan Price challenged the"
+com,"ruling; the call was upheld by replay"
+play,9,0,sches001,30,BBBB,W
+play,9,0,woodb004,00,,NP
+sub,rendt001,"Tony Renda",0,7,11
+play,9,0,rendt001,10,.B*B,DI.1-2
+play,9,0,rendt001,22,.B*B.FCS,K
+play,9,0,barnt001,32,BTSBBS,K
+data,er,adlet001,2
+data,er,woodb004,3
+data,er,hammj002,2
+data,er,rondh001,0
+data,er,chapa001,0
+id,CHN201609200
+version,2
+info,visteam,CIN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/20
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,hicke901
+info,ump1b,tumpj901
+info,ump2b,woodt901
+info,ump3b,estam901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,73
+info,winddir,fromcf
+info,windspeed,5
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,sunny
+info,timeofgame,178
+info,attendance,40586
+info,wp,lestj001
+info,lp,smitj004
+info,save,
+start,peraj003,"Jose Peraza",0,1,6
+start,rendt001,"Tony Renda",0,2,5
+start,vottj001,"Joey Votto",0,3,3
+start,duvaa001,"Adam Duvall",0,4,7
+start,philb001,"Brandon Phillips",0,5,4
+start,sches001,"Scott Schebler",0,6,9
+start,holtt001,"Tyler Holt",0,7,8
+start,cabrr001,"Ramon Cabrera",0,8,2
+start,smitj004,"Josh Smith",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,7
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,baezj001,"Javier Baez",1,7,5
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,peraj003,11,CBX,63/G
+play,1,0,rendt001,20,BBX,53/G
+play,1,0,vottj001,10,BX,53/G
+play,1,1,fowld001,32,SBBCFFBX,8/F
+play,1,1,bryak001,11,FBX,D7/L
+play,1,1,rizza001,12,FBFX,6/L-
+play,1,1,zobrb001,32,CFBFFBBFB,W
+play,1,1,russa002,12,CBCFFFS,K
+play,2,0,duvaa001,11,BCX,7/F
+play,2,0,philb001,12,SBSX,7/L
+play,2,0,sches001,22,BTCBX,43/G
+play,2,1,heywj001,11,CBX,8/F
+play,2,1,baezj001,12,CBSX,9/F
+play,2,1,rossd001,22,CBBSX,S9/G
+play,2,1,lestj001,00,X,D8/L.1-H
+play,2,1,fowld001,30,BBBB,W
+play,2,1,bryak001,01,FX,7/F
+play,3,0,holtt001,22,CBBFFH,HP
+play,3,0,cabrr001,11,FBX,4/P
+play,3,0,smitj004,21,>LBBX,S8/G.1-3
+play,3,0,peraj003,10,BX,6/L-
+play,3,0,rendt001,00,X,64(1)/FO/G
+play,3,1,rizza001,12,CFBS,K
+play,3,1,zobrb001,32,BCBCFBC,K
+play,3,1,russa002,12,BCFFX,53/G
+play,4,0,vottj001,22,FBFFBX,31/G
+play,4,0,duvaa001,10,BX,S9/L
+play,4,0,philb001,00,X,E4/FO/G.1-2
+play,4,0,sches001,11,FBX,64(1)3/GDP
+play,4,1,heywj001,00,,NP
+sub,peraw002,"Wandy Peralta",0,9,1
+play,4,1,heywj001,31,.BCBBB,W
+play,4,1,baezj001,00,X,13/G-.1-2
+play,4,1,rossd001,22,BBFFX,53/G
+play,4,1,lestj001,32,BBBCCB,W
+play,4,1,fowld001,01,CX,S8/G+.2-H;1-2
+play,4,1,bryak001,10,BX,D9/F.2-H;1-3
+play,4,1,rizza001,32,BC*BBCX,S7/L.3-H;2-H
+play,4,1,zobrb001,01,CX,53/G
+play,5,0,holtt001,11,CBX,63/G
+play,5,0,cabrr001,12,CCBS,K
+play,5,0,peraw002,00,,NP
+sub,selss001,"Steve Selsky",0,9,11
+play,5,0,selss001,22,.BCCBFX,S8/G
+play,5,0,peraj003,01,CX,T8/L.1-H
+play,5,0,rendt001,21,CBBX,9/F
+play,5,1,russa002,00,,NP
+sub,deloa001,"Abel de los Santos",0,9,1
+play,5,1,russa002,10,.BX,8/F
+play,5,1,heywj001,02,CFX,S9/L
+play,5,1,baezj001,01,C1H,HP.1-2
+play,5,1,rossd001,20,BBX,64(1)/FO/G.2-3
+play,5,1,lestj001,01,CX,6(1)/FO/G
+play,6,0,vottj001,11,BCX,S14/L
+play,6,0,duvaa001,02,CFS,K
+play,6,0,philb001,20,B*BX,D9/L.1-3
+play,6,0,sches001,22,BTFBC,K
+play,6,0,holtt001,21,CBBX,53/G
+play,6,1,fowld001,32,SBBBFB,W
+play,6,1,bryak001,12,F11F*BFF1X,9/F
+play,6,1,rizza001,10,B>C,SB2
+play,6,1,rizza001,22,B>C.BFX,S8/G+.2-H
+play,6,1,zobrb001,22,BSCBN,CS2(16)
+play,6,1,zobrb001,22,BSCBN.FFFFFS,K
+play,7,0,cabrr001,02,CSS,K
+play,7,0,deloa001,00,,NP
+sub,dejei002,"Ivan De Jesus",0,9,11
+play,7,0,dejei002,01,.CX,9/F
+play,7,0,peraj003,22,CBBFFFS,K
+play,7,1,russa002,00,,NP
+sub,diazj005,"Jumbo Diaz",0,9,1
+play,7,1,russa002,22,.SBSBFX,4/P
+play,7,1,heywj001,32,BBSBCB,W
+play,7,1,baezj001,21,BBSX,S8/L.1-2
+play,7,1,rossd001,10,BX,8/L
+play,7,1,lestj001,00,,NP
+sub,coghc001,"Chris Coghlan",1,9,11
+play,7,1,coghc001,32,.FBBBS>F>F>S,K
+play,8,0,rendt001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,8,0,rendt001,10,.BX,43/G
+play,8,0,vottj001,02,CCT,K
+play,8,0,duvaa001,31,BSBBB,W
+play,8,0,philb001,00,X,S9/L.1-3
+play,8,0,sches001,22,BFSBC,K
+play,8,1,fowld001,00,,NP
+sub,magim001,"Matt Magill",0,9,1
+play,8,1,fowld001,11,.FBX,S8/F-
+play,8,1,bryak001,02,FCX,S7/L.1-2
+play,8,1,rizza001,02,FFX,46(1)3/GDP.2-3
+play,8,1,zobrb001,02,CSX,7/F
+play,9,0,holtt001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,9,0,holtt001,32,.BCCBBFB,W
+play,9,0,cabrr001,31,BBCBX,64(1)3/GDP
+play,9,0,magim001,00,,NP
+sub,iribh001,"Hernan Iribarren",0,9,11
+play,9,0,iribh001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,9,0,iribh001,00,,NP
+sub,suare001,"Eugenio Suarez",0,9,11
+play,9,0,suare001,11,...BCX,63/G
+data,er,smitj004,1
+data,er,peraw002,4
+data,er,deloa001,1
+data,er,diazj005,0
+data,er,magim001,0
+data,er,lestj001,1
+data,er,edwac001,0
+data,er,cahit001,0
+data,er,woodt004,0
+id,CHN201609210
+version,2
+info,visteam,CIN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/21
+info,number,0
+info,starttime,7:06PM
+info,daynight,night
+info,usedh,false
+info,umphome,welkb901
+info,ump1b,fleta901
+info,ump2b,estam901
+info,ump3b,hicke901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,69
+info,winddir,fromlf
+info,windspeed,3
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,192
+info,attendance,40434
+info,wp,lackj001
+info,lp,stepr002
+info,save,
+start,peraj003,"Jose Peraza",0,1,6
+start,suare001,"Eugenio Suarez",0,2,5
+start,vottj001,"Joey Votto",0,3,3
+start,duvaa001,"Adam Duvall",0,4,7
+start,philb001,"Brandon Phillips",0,5,4
+start,sches001,"Scott Schebler",0,6,8
+start,selss001,"Steve Selsky",0,7,9
+start,barnt001,"Tucker Barnhart",0,8,2
+start,stepr002,"Robert Stephenson",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,heywj001,"Jason Heyward",1,5,9
+start,baezj001,"Javier Baez",1,6,6
+start,montm001,"Miguel Montero",1,7,2
+start,coghc001,"Chris Coghlan",1,8,7
+start,lackj001,"John Lackey",1,9,1
+play,1,0,peraj003,02,CFX,S9/L
+play,1,0,suare001,31,*BBSBX,8/F.1-3(E4/TH)
+play,1,0,vottj001,22,BCF*BX,53/G
+play,1,0,duvaa001,10,BX,9/L
+play,1,1,fowld001,11,BSH,HP
+play,1,1,bryak001,12,F*B1F1S,K
+play,1,1,rizza001,01,CB,WP.1-2
+play,1,1,rizza001,22,CB.BFX,S5/G.2-2
+play,1,1,zobrb001,12,BCFFFFX,S7/G.2-H;1-2
+play,1,1,heywj001,20,BBX,8/F.2-3
+play,1,1,baezj001,32,BBFFB>X,S5/G-/MREV.3-H;1-3
+com,"replay,1,baezj001,CHN,welkb901,CHI11,,N,M,CIN,C"
+com,"$when Javier Baez was called safe at 1B, Reds"
+com,"manager Bryan Price challenged the ruling; the"
+com,"call was upheld by replay"
+play,1,1,montm001,32,BF*BSB>X,43/G
+play,2,0,philb001,00,X,53/G
+play,2,0,sches001,01,FX,S8/G
+play,2,0,selss001,00,X,D9/F.1-H
+play,2,0,barnt001,32,BCF*B*BB,W
+play,2,0,stepr002,00,X,54/BG/SH.2-3;1-2
+play,2,0,peraj003,11,BFX,S7/G+.3-H;2XH(72)
+play,2,1,coghc001,22,CFBFFBX,S8/L+
+play,2,1,lackj001,22,LBFBL,K/BF
+play,2,1,fowld001,10,1BX,8/F
+play,2,1,bryak001,20,BB1X,4/P
+play,3,0,suare001,02,CFX,8/F
+play,3,0,vottj001,00,X,DGR/8/L+
+play,3,0,duvaa001,10,BX,53/G
+play,3,0,philb001,32,FBS*B*BFX,13/G
+play,3,1,rizza001,01,SX,43/G
+play,3,1,zobrb001,32,CCBBBB,W
+play,3,1,heywj001,22,*BBFF11X,8/L+
+play,3,1,baezj001,12,FBSX,S8/G.1-2
+play,3,1,montm001,32,*BBBCF>X,S7/L.2-H;1-3;B-2(E7/TH)
+play,3,1,coghc001,30,IIII,IW
+play,3,1,lackj001,00,X,8/F
+play,4,0,sches001,01,LX,8/F
+play,4,0,selss001,12,CCBS,K
+play,4,0,barnt001,12,CFBX,31/G
+play,4,1,fowld001,32,BBBCCX,HR/89/F
+play,4,1,bryak001,12,FSBFX,9/F
+play,4,1,rizza001,11,SBX,6/L
+play,4,1,zobrb001,22,BFBFX,S67/L+
+play,4,1,heywj001,00,,NP
+sub,magim001,"Matt Magill",0,9,1
+play,4,1,heywj001,20,.B1BX,S8/L+.1-3
+play,4,1,baezj001,00,X,4/P
+play,5,0,magim001,00,,NP
+sub,rendt001,"Tony Renda",0,9,11
+play,5,0,rendt001,22,.CBBFS,K
+play,5,0,peraj003,11,CBX,63/G
+play,5,0,suare001,31,FBBBX,4/P
+play,5,1,montm001,00,,NP
+sub,lorem002,"Michael Lorenzen",0,9,1
+play,5,1,montm001,11,.CBX,S8/G
+play,5,1,coghc001,32,FBBF*BFB,W.1-2
+play,5,1,lackj001,12,BCSS,K
+play,5,1,fowld001,12,CFBFFX,36(1)/FO/G+.2-3
+play,5,1,bryak001,12,BSFN,BK.3-H;1-2
+play,5,1,bryak001,22,BSFN.*BX,6/P
+play,6,0,vottj001,20,BBX,7/F
+play,6,0,duvaa001,10,BX,8/F
+play,6,0,philb001,11,CBX,13/G-
+play,6,1,rizza001,20,BBX,3/G
+play,6,1,zobrb001,01,CX,S8/L
+play,6,1,heywj001,30,B1BBB,W.1-2
+play,6,1,baezj001,01,CX,63/G.2-3;1-2
+play,6,1,montm001,12,FFBFFX,S8/G.3-H;2-H
+play,6,1,coghc001,00,,NP
+sub,woodb004,"Blake Wood",0,9,1
+play,6,1,coghc001,12,.FBFS,K
+play,7,0,sches001,02,CFX,53/G
+play,7,0,selss001,22,SBFBFS,K
+play,7,0,barnt001,12,CFBFS,K
+play,7,1,lackj001,00,,NP
+sub,ohler001,"Ross Ohlendorf",0,8,1
+play,7,1,lackj001,00,,NP
+sub,cabrr001,"Ramon Cabrera",0,9,2
+play,7,1,lackj001,00,,NP
+sub,almoa002,"Albert Almora",1,9,11
+play,7,1,almoa002,00,...X,8/F
+play,7,1,fowld001,10,BX,S7/L+
+play,7,1,bryak001,31,SBBBX,HR/7/F.1-H
+play,7,1,rizza001,32,BFBCBFB,W
+play,7,1,zobrb001,21,BBFX,5/P5F
+play,7,1,heywj001,00,X,43/G
+play,8,0,cabrr001,00,,NP
+sub,rondh001,"Hector Rondon",1,8,1
+play,8,0,cabrr001,00,,NP
+sub,almoa002,"Albert Almora",1,9,7
+play,8,0,cabrr001,22,..CCBBH,HP
+play,8,0,peraj003,02,FCX,9/L
+play,8,0,suare001,01,SX,54(1)/FO/G/UREV
+com,"replay,8,suare001,CIN,welkb901,CHI11,,Y,U,,C"
+com,"$when Eugenio Suarez was called out at 1B, acting"
+com,"crew chief Bill Welke requested a review; the"
+com,"call was overturned by replay"
+play,8,0,vottj001,00,,NP
+sub,montm002,"Mike Montgomery",1,8,1
+play,8,0,vottj001,22,.BBFFFX,6(1)/FO/G
+play,8,1,baezj001,00,,NP
+sub,cingt001,"Tony Cingrani",0,3,1
+play,8,1,baezj001,00,,NP
+sub,dejei002,"Ivan De Jesus",0,8,3
+play,8,1,baezj001,31,..BBBCX,S7/L+
+play,8,1,montm001,01,SB,WP.1-2
+play,8,1,montm001,11,SB.X,8/F.2-3
+play,8,1,montm002,02,CFS,K
+play,8,1,almoa002,20,BBX,7/F
+play,9,0,duvaa001,01,CX,S7/L
+play,9,0,philb001,01,CX,9/F
+play,9,0,sches001,11,BSX,46(1)/FO/G
+play,9,0,selss001,00,,NP
+sub,smitj002,"Joe Smith",1,8,1
+play,9,0,selss001,02,.CCS,K
+data,er,stepr002,4
+data,er,magim001,0
+data,er,lorem002,3
+data,er,woodb004,0
+data,er,ohler001,2
+data,er,cingt001,0
+data,er,lackj001,2
+data,er,rondh001,0
+data,er,montm002,0
+data,er,smitj002,0
+id,CHN201609230
+version,2
+info,visteam,SLN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/23
+info,number,0
+info,starttime,1:22PM
+info,daynight,day
+info,usedh,false
+info,umphome,buckc901
+info,ump1b,reynj901
+info,ump2b,culbf901
+info,ump3b,gonzm901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,frisd701
+info,temp,71
+info,winddir,fromlf
+info,windspeed,9
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,173
+info,attendance,40791
+info,wp,arrij001
+info,lp,leakm001
+info,save,
+start,carpm002,"Matt Carpenter",0,1,4
+start,gyorj001,"Jedd Gyorko",0,2,6
+start,piscs001,"Stephen Piscotty",0,3,9
+start,adamm002,"Matt Adams",0,4,3
+start,moliy001,"Yadier Molina",0,5,2
+start,gricr001,"Randal Grichuk",0,6,8
+start,peraj001,"Jhonny Peralta",0,7,5
+start,wongk001,"Kolten Wong",0,8,7
+start,leakm001,"Mike Leake",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,coghc001,"Chris Coghlan",1,7,7
+start,montm001,"Miguel Montero",1,8,2
+start,arrij001,"Jake Arrieta",1,9,1
+play,1,0,carpm002,22,BBCFS,K
+play,1,0,gyorj001,02,FSS,K
+play,1,0,piscs001,02,FCC,K
+play,1,1,fowld001,32,CBBBFB,W
+play,1,1,bryak001,02,CFX,S7/G.1-3
+play,1,1,rizza001,00,B,WP.3-H(NR);1-2
+play,1,1,rizza001,12,B.FFFX,D7/L.2-H
+play,1,1,zobrb001,22,BBFFB,WP.2-3
+play,1,1,zobrb001,32,BBFFB.X,S9/G.3-H
+play,1,1,russa002,00,X,54(1)/FO/G
+play,1,1,heywj001,11,CBX,46(1)/FO/G
+play,1,1,coghc001,10,BX,D9/G.1-H;B-3(TH)
+play,1,1,montm001,22,BCFBX,6/P
+play,2,0,adamm002,22,BFCBX,S8/G
+play,2,0,moliy001,32,BC1SFBFFFBX,54(1)3/GDP
+play,2,0,gricr001,02,SSS,K
+play,2,1,arrij001,22,BBSCX,8/F
+play,2,1,fowld001,00,X,8/F
+play,2,1,bryak001,32,CBSBBX,53/G
+play,3,0,peraj001,31,BCBBX,S7/F-
+play,3,0,wongk001,11,SBX,S8/L.1-2
+play,3,0,leakm001,02,F2CX,35(2)4/BG/GDP.1-2
+play,3,0,carpm002,12,SF*BS,K
+play,3,1,rizza001,21,BCBX,D9/L
+play,3,1,zobrb001,21,CBBX,9/F.2-3
+play,3,1,russa002,02,CFX,4/P3F
+play,3,1,heywj001,31,CBBBB,W
+play,3,1,coghc001,20,BB>B,SB2
+play,3,1,coghc001,30,BB>B.B,W
+play,3,1,montm001,12,CBFS,K
+play,4,0,gyorj001,22,BSCFBX,63/G
+play,4,0,piscs001,01,CX,8/F
+play,4,0,adamm002,32,FBBSBB,W
+play,4,0,moliy001,02,CS+1,PO1(23)
+play,4,1,arrij001,01,FX,S7/G
+play,4,1,fowld001,12,CBFX,9/F
+play,4,1,bryak001,21,CBBX,S48/G.1-2
+play,4,1,rizza001,00,,NP
+sub,kiekd001,"Dean Kiekhefer",0,9,1
+play,4,1,rizza001,22,.BCBCX,S68/L.2-3;1-2
+play,4,1,zobrb001,00,,NP
+sub,socom001,"Miguel Socolovich",0,9,1
+play,4,1,zobrb001,10,.BX,46(1)/FO/G.3-H;2-3
+play,4,1,russa002,00,>B,SB2
+play,4,1,russa002,32,>B.BBCSFX,63/G
+play,5,0,moliy001,02,SFS,K
+play,5,0,gricr001,12,CBCC,K
+play,5,0,peraj001,21,BSBX,9/L
+play,5,1,heywj001,12,BFSX,43/G-
+play,5,1,coghc001,32,BCBCBFX,43/G
+play,5,1,montm001,00,X,3/G
+play,6,0,wongk001,21,SBBX,13/G
+play,6,0,socom001,00,,NP
+sub,garcg002,"Greg Garcia",0,9,11
+play,6,0,garcg002,21,.BCBX,S9/L
+play,6,0,carpm002,00,X,8/F
+play,6,0,gyorj001,22,FSBBS,K
+play,6,1,arrij001,00,,NP
+sub,roset001,"Trevor Rosenthal",0,9,1
+play,6,1,arrij001,02,.SCS,K
+play,6,1,fowld001,00,X,43/G
+play,6,1,bryak001,32,CBCBBFB,W
+play,6,1,rizza001,02,CS1X,6/L-
+play,7,0,piscs001,10,BX,43/G
+play,7,0,adamm002,12,BFFS,K
+play,7,0,moliy001,01,CX,S7/L
+play,7,0,gricr001,22,BSSBFS,K
+play,7,1,zobrb001,00,,NP
+sub,tuivs001,"Sam Tuivailala",0,9,1
+play,7,1,zobrb001,31,.CBBBB,W
+play,7,1,russa002,12,CBCX,6/P
+play,7,1,heywj001,32,BBBCFX,64(1)/FO/G
+play,7,1,coghc001,32,CBBBF>B,W.1-2
+play,7,1,montm001,00,,NP
+sub,dukez001,"Zach Duke",0,9,1
+play,7,1,montm001,00,,NP
+sub,solej001,"Jorge Soler",1,8,11
+play,7,1,solej001,22,..FFB*BS,K
+play,8,0,peraj001,00,,NP
+sub,zobrb001,"Ben Zobrist",1,4,7
+play,8,0,peraj001,00,,NP
+sub,contw001,"Willson Contreras",1,9,2
+play,8,0,peraj001,00,,NP
+sub,strop001,"Pedro Strop",1,8,1
+play,8,0,peraj001,00,,NP
+sub,baezj001,"Javier Baez",1,7,4
+play,8,0,peraj001,30,....BBBB,W
+play,8,0,wongk001,12,CFBS,K
+play,8,0,dukez001,00,,NP
+sub,mossb001,"Brandon Moss",0,9,11
+play,8,0,mossb001,22,.BFSBX,56(1)3/GDP
+play,8,1,contw001,00,,NP
+sub,willj003,"Jerome Williams",0,9,1
+play,8,1,contw001,32,.BSBFBFX,S9/L
+play,8,1,fowld001,21,FBBX,8/F
+play,8,1,bryak001,32,CBBS*B11X,7/F
+play,8,1,rizza001,22,CFBBFFT,K
+play,9,0,carpm002,00,,NP
+sub,woodt004,"Travis Wood",1,8,1
+play,9,0,carpm002,32,.BCFBFBC,K
+play,9,0,gyorj001,00,,NP
+sub,edwac001,"Carl Edwards",1,8,1
+play,9,0,gyorj001,12,.CBSX,9/F
+play,9,0,piscs001,02,SFFS,K
+data,er,leakm001,5
+data,er,kiekd001,0
+data,er,socom001,0
+data,er,roset001,0
+data,er,tuivs001,0
+data,er,dukez001,0
+data,er,willj003,0
+data,er,arrij001,0
+data,er,strop001,0
+data,er,woodt004,0
+data,er,edwac001,0
+id,CHN201609240
+version,2
+info,visteam,SLN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/24
+info,number,0
+info,starttime,12:05PM
+info,daynight,day
+info,usedh,false
+info,umphome,reynj901
+info,ump1b,culbf901
+info,ump2b,gonzm901
+info,ump3b,buckc901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,speaa701
+info,temp,67
+info,winddir,fromrf
+info,windspeed,7
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,overcast
+info,timeofgame,199
+info,attendance,40785
+info,wp,reyea004
+info,lp,hammj002
+info,save,
+start,carpm002,"Matt Carpenter",0,1,4
+start,piscs001,"Stephen Piscotty",0,2,9
+start,mossb001,"Brandon Moss",0,3,7
+start,peraj001,"Jhonny Peralta",0,4,5
+start,adamm002,"Matt Adams",0,5,3
+start,moliy001,"Yadier Molina",0,6,2
+start,gricr001,"Randal Grichuk",0,7,8
+start,diaza003,"Aledmys Diaz",0,8,6
+start,reyea004,"Alex Reyes",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,5
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,solej001,"Jorge Soler",1,7,7
+start,contw001,"Willson Contreras",1,8,2
+start,hammj002,"Jason Hammel",1,9,1
+play,1,0,carpm002,12,CCBC,K
+play,1,0,piscs001,02,FFX,9/F
+play,1,0,mossb001,31,BBSBB,W
+play,1,0,peraj001,32,BB1FFFB>X,S9/L-.1-3
+play,1,0,adamm002,00,H,HP/MREV.1-2
+com,"replay,1,adamm002,SLN,culbf901,CHI11,,Y,M,SLN,I"
+com,"$when Matt Adams was ruled not to have been hit by"
+com,"a pitch, Cardinals manager Mike Matheny challenged"
+com,"the ruling; the call was overturned by replay"
+play,1,0,moliy001,01,SX,D7/G.3-H;2-H;1-3
+play,1,0,gricr001,01,CX,S7/L.3-H;2-H;B-2(TH)
+play,1,0,diaza003,22,BSC*BS,K
+play,1,1,fowld001,11,BSX,S9/L
+play,1,1,bryak001,32,B*BBCFF*B,W.1-2
+play,1,1,rizza001,12,CSFBS,K
+play,1,1,zobrb001,10,BX,T9/L.2-H;1-H
+play,1,1,russa002,32,SBFBBS,K
+play,1,1,heywj001,00,X,6/P
+play,2,0,reyea004,22,BSFBX,4/L-
+play,2,0,carpm002,11,BCX,8/F
+play,2,0,piscs001,11,BCX,HR/78/F
+play,2,0,mossb001,00,X,4/P
+play,2,1,solej001,32,FSBBBFFB,W
+play,2,1,contw001,12,BCFFS,K
+play,2,1,hammj002,00,X,S7/G.1-3
+play,2,1,fowld001,22,SBFBFX,D9/L.3-H;1-3
+play,2,1,bryak001,01,CX,6/P
+play,2,1,rizza001,22,BCBFS,K
+play,3,0,peraj001,10,BX,S8/G+
+play,3,0,adamm002,12,FBFFFFFX,7/F
+play,3,0,moliy001,01,SX,S9/L-.1-2
+play,3,0,gricr001,00,,NP
+sub,montm002,"Mike Montgomery",1,9,1
+play,3,0,gricr001,02,.FSX,D8/L.2-H;1-3
+play,3,0,diaza003,31,BCBB*B,W
+play,3,0,reyea004,01,CX,46(1)3/GDP
+play,3,1,zobrb001,12,CFBFX,3/G-
+play,3,1,russa002,32,CBCBBX,S1/G-
+play,3,1,heywj001,31,CBBBX,4/P
+play,3,1,solej001,21,1BBFX,9/F
+play,4,0,carpm002,22,BCCBFFFX,9/L
+play,4,0,piscs001,01,FX,31/G
+play,4,0,mossb001,02,CCS,K
+play,4,1,contw001,12,CFFBX,63/G+
+play,4,1,montm002,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,4,1,lastt001,12,.BCFFX,3/G
+play,4,1,fowld001,01,CX,T8/L+
+play,4,1,bryak001,32,BSCBFBFC,K
+play,5,0,peraj001,00,,NP
+sub,cahit001,"Trevor Cahill",1,9,1
+play,5,0,peraj001,11,.CBX,S8/L
+play,5,0,adamm002,00,X,3(B)6(1)/GDP
+play,5,0,moliy001,10,BX,31/G
+play,5,1,rizza001,12,CSBFX,7/L
+play,5,1,zobrb001,32,BCBFBB,W
+play,5,1,russa002,32,BBFFBS,K
+play,5,1,heywj001,32,CBBBC>F>X,5/P5F
+play,6,0,gricr001,22,BFFBFFC,K
+play,6,0,diaza003,31,BSBBB,W
+play,6,0,reyea004,00,,NP
+sub,hazej001,"Jeremy Hazelbaker",0,9,11
+play,6,0,hazej001,00,,NP
+sub,woodt004,"Travis Wood",1,9,1
+play,6,0,hazej001,00,,NP
+sub,gyorj001,"Jedd Gyorko",0,9,11
+play,6,0,gyorj001,12,...CBFFS,K
+play,6,0,carpm002,01,CX,13/G
+play,6,1,solej001,00,,NP
+sub,bowmm001,"Matt Bowman",0,9,1
+play,6,1,solej001,00,.X,53/G-
+play,6,1,contw001,12,CFBX,S6/G
+play,6,1,woodt004,00,,NP
+sub,montm001,"Miguel Montero",1,9,11
+play,6,1,montm001,20,.*BBX,16(1)3/GDP
+play,7,0,piscs001,00,,NP
+sub,rondh001,"Hector Rondon",1,9,1
+play,7,0,piscs001,22,.BFFFBX,D7/G+
+play,7,0,mossb001,22,FFBB+2FX,31/G.2-3
+play,7,0,peraj001,30,B+3BB*B,W
+play,7,0,adamm002,22,CFFBBX,D7/L.3-H;1-3
+play,7,0,moliy001,00,,NP
+sub,phamt001,"Tommy Pham",0,5,12
+play,7,0,moliy001,02,.FFFX,S7/G.3-H;2-H
+play,7,0,gricr001,00,,NP
+sub,penaf002,"Felix Pena",1,9,1
+play,7,0,gricr001,02,.FSFN,OA/MREV
+com,"replay,7,gricr001,SLN,culbf901,CHI11,,Y,M,CHN,I"
+com,"$when Randal Grichuk was ruled to have been hit by"
+com,"a pitch, Cubs manager Joe Maddon challenged the"
+com,"ruling; the call was overturned to a foul ball"
+com,"by replay"
+play,7,0,gricr001,02,.FSFS,K
+play,7,0,diaza003,22,BCSFBX,64(1)/FO/G
+play,7,1,fowld001,00,,NP
+sub,mossb001,"Brandon Moss",0,3,3
+play,7,1,fowld001,00,,NP
+sub,phamt001,"Tommy Pham",0,5,7
+play,7,1,fowld001,02,..FFFS,K
+play,7,1,bryak001,12,CBSS,K
+play,7,1,rizza001,00,,NP
+sub,baezj001,"Javier Baez",1,3,11
+play,7,1,baezj001,10,.BX,53/G-
+play,8,0,bowmm001,00,,NP
+sub,baezj001,"Javier Baez",1,3,6
+play,8,0,bowmm001,00,,NP
+sub,coghc001,"Chris Coghlan",1,4,3
+play,8,0,bowmm001,00,,NP
+sub,szczm001,"Matt Szczur",1,5,9
+play,8,0,bowmm001,00,,NP
+sub,kawam001,"Munenori Kawasaki",1,6,4
+play,8,0,bowmm001,00,,NP
+sub,zastr001,"Rob Zastryzny",1,9,1
+play,8,0,bowmm001,00,,NP
+sub,martj008,"Jose Martinez",0,9,11
+play,8,0,martj008,31,......BBBCX,D7/L+
+play,8,0,carpm002,12,BFSX,7/F
+play,8,0,piscs001,12,BCSFX,S7/L.2-H
+play,8,0,mossb001,20,BBX,8/L
+play,8,0,peraj001,21,BFBX,3/P3F
+play,8,1,coghc001,00,,NP
+sub,kellc002,"Carson Kelly",0,6,2
+play,8,1,coghc001,00,,NP
+sub,garcg002,"Greg Garcia",0,8,6
+play,8,1,coghc001,00,,NP
+sub,dukez001,"Zach Duke",0,9,1
+play,8,1,coghc001,21,...BCBX,8/F
+play,8,1,szczm001,12,BCSC,K
+play,8,1,kawam001,12,BFCS,K
+play,9,0,phamt001,00,,NP
+sub,patts002,"Spencer Patton",1,9,1
+play,9,0,phamt001,02,.CCC,K
+play,9,0,kellc002,01,SX,E6/TH/G
+play,9,0,gricr001,32,BBSFBT,K
+play,9,0,garcg002,22,BFBSFX,S9/L.1-2
+play,9,0,dukez001,00,,NP
+sub,penab002,"Brayan Pena",0,9,11
+play,9,0,penab002,01,.CX,46(1)/FO/G
+play,9,1,solej001,00,,NP
+sub,oh--s001,"Seung Hwan Oh",0,9,1
+play,9,1,solej001,00,.X,7/F
+play,9,1,contw001,01,CX,HR/7/F
+play,9,1,patts002,00,,NP
+sub,almoa002,"Albert Almora",1,9,11
+play,9,1,almoa002,22,.BBSFX,9/F
+play,9,1,fowld001,01,CX,6/P
+data,er,reyea004,3
+data,er,bowmm001,0
+data,er,dukez001,0
+data,er,oh--s001,1
+data,er,hammj002,6
+data,er,montm002,0
+data,er,cahit001,0
+data,er,woodt004,0
+data,er,rondh001,3
+data,er,penaf002,0
+data,er,zastr001,1
+data,er,patts002,0
+id,CHN201609250
+version,2
+info,visteam,SLN
+info,hometeam,CHN
+info,site,CHI11
+info,date,2016/09/25
+info,number,0
+info,starttime,7:08PM
+info,daynight,night
+info,usedh,false
+info,umphome,culbf901
+info,ump1b,gonzm901
+info,ump2b,buckc901
+info,ump3b,reynj901
+info,howscored,park
+info,pitches,pitches
+info,oscorer,roseb701
+info,temp,81
+info,winddir,tolf
+info,windspeed,3
+info,fieldcond,unknown
+info,precip,unknown
+info,sky,unknown
+info,timeofgame,189
+info,attendance,40859
+info,wp,lestj001
+info,lp,martc006
+info,save,chapa001
+start,carpm002,"Matt Carpenter",0,1,4
+start,piscs001,"Stephen Piscotty",0,2,9
+start,peraj001,"Jhonny Peralta",0,3,5
+start,mossb001,"Brandon Moss",0,4,3
+start,moliy001,"Yadier Molina",0,5,2
+start,gyorj001,"Jedd Gyorko",0,6,6
+start,gricr001,"Randal Grichuk",0,7,8
+start,martj008,"Jose Martinez",0,8,7
+start,martc006,"Carlos Martinez",0,9,1
+start,fowld001,"Dexter Fowler",1,1,8
+start,bryak001,"Kris Bryant",1,2,7
+start,rizza001,"Anthony Rizzo",1,3,3
+start,zobrb001,"Ben Zobrist",1,4,4
+start,russa002,"Addison Russell",1,5,6
+start,heywj001,"Jason Heyward",1,6,9
+start,baezj001,"Javier Baez",1,7,5
+start,rossd001,"David Ross",1,8,2
+start,lestj001,"Jon Lester",1,9,1
+play,1,0,carpm002,32,CSFBBBFX,7/F
+play,1,0,piscs001,01,FX,4/P
+play,1,0,peraj001,32,CBSBBFX,63/G
+play,1,1,fowld001,31,BCBBB,W
+play,1,1,bryak001,00,X,64(1)/FO/G
+play,1,1,rizza001,31,BBFBX,6/P
+play,1,1,zobrb001,21,BBCX,S5/G+.1-2
+play,1,1,russa002,01,CX,64(1)/FO/G
+play,2,0,mossb001,20,BBX,43/G
+play,2,0,moliy001,31,FBBBX,D9/L+
+play,2,0,gyorj001,32,F*BB*BCFS,K
+play,2,0,gricr001,00,X,7/F
+play,2,1,heywj001,12,CBTX,S7/G
+play,2,1,baezj001,12,CBSX,8/F
+play,2,1,rossd001,32,*BFSBB>S,K+SB2
+play,2,1,lestj001,11,SBX,3/G
+play,3,0,martj008,10,BX,53/G
+play,3,0,martc006,12,BCFS,K
+play,3,0,carpm002,12,CSBS,K
+play,3,1,fowld001,22,CFBFBS,K
+play,3,1,bryak001,32,BSBSBB,W
+play,3,1,rizza001,02,FCFX,65(1)3/GDP
+play,4,0,piscs001,00,X,4/P
+play,4,0,peraj001,22,BCBCS,K
+play,4,0,mossb001,32,SBSBFFBX,53/G-
+play,4,1,zobrb001,11,FBX,43/G
+play,4,1,russa002,00,X,63/G
+play,4,1,heywj001,22,CBFBX,43/G
+play,5,0,moliy001,02,CFS,K
+play,5,0,gyorj001,22,FBBSFFS,K
+play,5,0,gricr001,11,BFX,63/G
+play,5,1,baezj001,22,CFBFBS,K
+play,5,1,rossd001,10,BX,HR/78/F
+play,5,1,lestj001,02,SCFFS,K
+play,5,1,fowld001,11,SBX,S8/G
+play,5,1,bryak001,22,1SBFB>B,SB2
+play,5,1,bryak001,32,1SBFB>B.B,W
+play,5,1,rizza001,22,FBBCN,SB3
+play,5,1,rizza001,32,FBBCN.B>X,43/G
+play,6,0,martj008,11,BFX,S7/G+
+play,6,0,martc006,00,X,FC2/BG/SH/MREV.1-2
+com,"replay,6,martc006,SLN,culbf901,CHI11,,Y,M,SLN,C"
+com,"$when Jose Martinez was called out at 2B, Cardinals"
+com,"manager Mike Matheny challenged the ruling; the"
+com,"call was overturned by replay"
+play,6,0,carpm002,00,X,56(1)3/GDP.2-3
+play,6,0,piscs001,11,FBX,53/G
+play,6,1,zobrb001,32,CBBCBX,D7/L
+play,6,1,russa002,00,X,D7/L/MREV.2-H
+com,"replay,6,russa002,CHN,culbf901,CHI11,,Y,M,CHN,O"
+com,"$when Addison Russell's hit to LF was ruled foul,"
+com,"Cubs manager Joe Maddon challenged the ruling; the"
+com,"call was overturned by replay"
+play,6,1,heywj001,02,FFS,K
+play,6,1,baezj001,01,FX,53/G
+play,6,1,rossd001,30,IIII,IW
+play,6,1,lestj001,02,SFFC,K
+play,7,0,peraj001,12,CBFT,K
+play,7,0,mossb001,10,BX,8/F
+play,7,0,moliy001,00,,NP
+sub,contw001,"Willson Contreras",1,8,2
+play,7,0,moliy001,22,.BFFFBX,S9/L-
+play,7,0,gyorj001,32,CBFBB>B,W.1-2
+play,7,0,gricr001,00,,NP
+sub,edwac001,"Carl Edwards",1,9,1
+play,7,0,gricr001,22,.SCBF*BS,K
+play,7,1,fowld001,00,,NP
+sub,siegk001,"Kevin Siegrist",0,9,1
+play,7,1,fowld001,12,.BSFFC,K
+play,7,1,bryak001,12,BSSC,K
+play,7,1,rizza001,11,CBX,3/G-
+play,8,0,martj008,30,BBBB,W
+play,8,0,siegk001,00,,NP
+sub,grimj002,"Justin Grimm",1,9,1
+play,8,0,siegk001,00,,NP
+sub,adamm002,"Matt Adams",0,9,11
+play,8,0,adamm002,22,..FBS*BT,K
+play,8,0,carpm002,00,X,S9/L.1-3
+play,8,0,piscs001,12,TBCS,K
+play,8,0,peraj001,32,CFB*BB>X,S8/L.3-H;1-3
+play,8,0,mossb001,12,BSFX,8/L
+play,8,1,zobrb001,00,,NP
+sub,dukez001,"Zach Duke",0,9,1
+play,8,1,zobrb001,11,.BCX,S8/G+
+play,8,1,russa002,32,1FBFFBBB,W.1-2
+play,8,1,heywj001,22,BBLLL,K/BF
+play,8,1,baezj001,00,,NP
+sub,broxj001,"Jonathan Broxton",0,9,1
+play,8,1,baezj001,00,.H,HP/MREV.2-3;1-2
+com,"replay,8,baezj001,CHN,culbf901,CHI11,,N,M,SLN,I"
+com,"$when Javier Baez was ruled to have been hit by a"
+com,"pitch, Cardinals manager Mike Matheny challenged"
+com,"the ruling; the call was upheld by replay"
+play,8,1,contw001,10,BX,S9/F.3-H;2XH(9342);1-3(TH);B-2
+play,8,1,grimj002,00,,NP
+sub,lastt001,"Tommy La Stella",1,9,11
+play,8,1,lastt001,22,.BCBSS,K
+play,9,0,moliy001,00,,NP
+sub,chapa001,"Aroldis Chapman",1,9,1
+play,9,0,moliy001,21,.BCBX,63/G
+play,9,0,gyorj001,31,BBBCX,8/F
+play,9,0,gricr001,30,BBBB,W
+play,9,0,martj008,00,>C,DI.1-2
+play,9,0,martj008,12,>C.BCFFFC,K
+data,er,martc006,2
+data,er,siegk001,0
+data,er,dukez001,1
+data,er,broxj001,0
+data,er,lestj001,0
+data,er,edwac001,1
+data,er,grimj002,0
+data,er,chapa001,0

--- a/tests/test_multiple_games.rs
+++ b/tests/test_multiple_games.rs
@@ -1,0 +1,21 @@
+extern crate retrosheet;
+
+use retrosheet::Parser;
+
+use std::fs::File;
+use std::io::Read;
+
+#[test]
+fn test_multiple_games() {
+    let mut parser = Parser::new();
+
+    let file_name = format!("{}/test_resources/2016CHN.EVN", env!("CARGO_MANIFEST_DIR"));
+    let mut file = File::open(file_name).unwrap();
+
+    let mut buf: Vec<u8> = vec![];
+    file.read_to_end(&mut buf).unwrap();
+
+    let result = parser.parse(&buf);
+
+    assert!(result.is_ok(), "{}", result.err().unwrap());
+}

--- a/tests/test_multiple_games.rs
+++ b/tests/test_multiple_games.rs
@@ -1,6 +1,6 @@
 extern crate retrosheet;
 
-use retrosheet::Parser;
+use retrosheet::{Parser, ParserError};
 
 use std::fs::File;
 use std::io::Read;
@@ -17,5 +17,16 @@ fn test_multiple_games() {
 
     let result = parser.parse(&buf);
 
-    assert!(result.is_ok(), "{}", result.err().unwrap());
+    match result {
+        Ok(_) => {},
+        Err(e) => {
+            match e {
+                ParserError::BytesRemaining(bytes) => {
+                    let first_chunk: Vec<u8> = bytes.into_iter().take(50).collect();
+                    assert!(false, "unfinished: {}...", ::std::str::from_utf8(&first_chunk).unwrap())
+                },
+                _ => assert!(false, "{}", e),
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add a test for multiple games in a row; that is, parsing an entire event file.

This required also adding a variety of missing play modifiers and descriptions and so on.